### PR TITLE
feat: add AI chatbot with OpenRouter integration

### DIFF
--- a/background.js
+++ b/background.js
@@ -32,6 +32,7 @@ importScripts(
   'bg/fetcher.js',         // fetchJobs, fetchProjectDetails, cleanTitle
   'bg/tracker.js',         // checkTrackedProjects
   'bg/job-checker.js',     // checkForNewJobs
+  'bg/openrouter.js',      // generateOpenRouterProposal
   'bg/signalr.js',         // initializeSignalR
   'bg/install.js',         // onInstalled handler
   'bg/alarm-handler.js',   // onAlarm handler

--- a/bg/install.js
+++ b/bg/install.js
@@ -16,7 +16,7 @@ chrome.runtime.onInstalled.addListener(() => {
       interval: 1,
       aiProvider: 'chatgpt',
       aiChatUrl: 'https://chatgpt.com/',
-      openRouterModel: 'openai/gpt-4o-mini'
+      openRouterModel: 'openrouter/hunter-alpha'
     };
 
     if (!data.settings) {

--- a/bg/install.js
+++ b/bg/install.js
@@ -8,15 +8,24 @@ chrome.runtime.onInstalled.addListener(() => {
 
   chrome.storage.local.get(['settings', 'seenJobs', 'stats', 'trackedProjects', 'prompts', 'recentJobs', 'proposalTemplate'], (data) => {
     const changes = {};
+    const defaultSettings = {
+      development: true,
+      ai: true,
+      all: true,
+      sound: true,
+      interval: 1,
+      aiProvider: 'chatgpt',
+      aiChatUrl: 'https://chatgpt.com/',
+      openRouterModel: 'openai/gpt-4o-mini'
+    };
 
     if (!data.settings) {
-      changes.settings = {
-        development: true,
-        ai: true,
-        all: true,
-        sound: true,
-        interval: 1
-      };
+      changes.settings = defaultSettings;
+    } else {
+      const mergedSettings = { ...defaultSettings, ...data.settings };
+      if (JSON.stringify(mergedSettings) !== JSON.stringify(data.settings)) {
+        changes.settings = mergedSettings;
+      }
     }
 
     if (!data.seenJobs) changes.seenJobs = [];

--- a/bg/message-handler.js
+++ b/bg/message-handler.js
@@ -131,25 +131,38 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
     };
 
+    const finalize = async (result) => {
+      if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+      await updateChatSession((session) => {
+        session.messages = (session.messages || []).filter((m) => !m.pending);
+        session.messages.push({ role: 'assistant', content: result.text });
+        session.model = result.model || session.model;
+      });
+      sendResponse({ success: true, ...result });
+    };
+
+    const fail = async (error) => {
+      if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+      console.error('OpenRouter generation error:', error);
+      const errorMsg = error.message || 'OpenRouter request failed';
+      await updateChatSession((session) => {
+        session.messages = (session.messages || []).filter((m) => !m.pending);
+        session.messages.push({ role: 'assistant', content: '\u062a\u0639\u0630\u0631 \u062a\u0648\u0644\u064a\u062f \u0627\u0644\u0631\u062f: ' + errorMsg });
+      });
+      sendResponse({ success: false, error: errorMsg });
+    };
+
+    // Try streaming first, fall back to non-streaming if the provider rejects it
     generateOpenRouterProposalStream(message, onChunk)
-      .then(async (result) => {
-        if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
-        await updateChatSession((session) => {
-          session.messages = (session.messages || []).filter((m) => !m.pending);
-          session.messages.push({ role: 'assistant', content: result.text });
-          session.model = result.model || session.model;
-        });
-        sendResponse({ success: true, ...result });
-      })
-      .catch(async (error) => {
-        if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
-        console.error('OpenRouter generation error:', error);
-        const errorMsg = error.message || 'OpenRouter request failed';
-        await updateChatSession((session) => {
-          session.messages = (session.messages || []).filter((m) => !m.pending);
-          session.messages.push({ role: 'assistant', content: '\u062a\u0639\u0630\u0631 \u062a\u0648\u0644\u064a\u062f \u0627\u0644\u0631\u062f: ' + errorMsg });
-        });
-        sendResponse({ success: false, error: errorMsg });
+      .then(finalize)
+      .catch(async (streamError) => {
+        console.warn('Streaming failed, falling back to non-streaming:', streamError.message);
+        try {
+          const result = await generateOpenRouterProposal(message);
+          await finalize(result);
+        } catch (fallbackError) {
+          await fail(fallbackError);
+        }
       });
     return true;
   }

--- a/bg/message-handler.js
+++ b/bg/message-handler.js
@@ -3,6 +3,20 @@
 // Depends on: constants.js, filters.js, notifications.js, job-checker.js, audio.js
 // ==========================================
 
+const BG_CHAT_SESSION_KEY = 'openRouterChatSession';
+
+/**
+ * Read-modify-write the chat session in storage.
+ * The mutator function receives the session object and can modify it in place.
+ */
+async function updateChatSession(mutator) {
+  const data = await chrome.storage.local.get([BG_CHAT_SESSION_KEY]);
+  const session = data[BG_CHAT_SESSION_KEY] || {};
+  mutator(session);
+  session.updatedAt = Date.now();
+  await chrome.storage.local.set({ [BG_CHAT_SESSION_KEY]: session });
+}
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
   if (message.action === 'checkNow') {
@@ -90,11 +104,52 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
 
   if (message.action === 'generateOpenRouterProposal') {
-    generateOpenRouterProposal(message)
-      .then((result) => sendResponse({ success: true, ...result }))
-      .catch((error) => {
+    const STREAM_FLUSH_MS = 300;
+    let lastFlush = 0;
+    let flushTimer = null;
+
+    const flushChunk = async (text) => {
+      lastFlush = Date.now();
+      await updateChatSession((session) => {
+        const msgs = session.messages || [];
+        const pendingIdx = msgs.findIndex((m) => m.pending);
+        if (pendingIdx !== -1) {
+          msgs[pendingIdx] = { role: 'assistant', content: text, pending: true };
+        }
+      });
+    };
+
+    const onChunk = (accumulated) => {
+      const now = Date.now();
+      if (now - lastFlush >= STREAM_FLUSH_MS) {
+        flushChunk(accumulated);
+      } else if (!flushTimer) {
+        flushTimer = setTimeout(() => {
+          flushTimer = null;
+          flushChunk(accumulated);
+        }, STREAM_FLUSH_MS - (now - lastFlush));
+      }
+    };
+
+    generateOpenRouterProposalStream(message, onChunk)
+      .then(async (result) => {
+        if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+        await updateChatSession((session) => {
+          session.messages = (session.messages || []).filter((m) => !m.pending);
+          session.messages.push({ role: 'assistant', content: result.text });
+          session.model = result.model || session.model;
+        });
+        sendResponse({ success: true, ...result });
+      })
+      .catch(async (error) => {
+        if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
         console.error('OpenRouter generation error:', error);
-        sendResponse({ success: false, error: error.message || 'OpenRouter request failed' });
+        const errorMsg = error.message || 'OpenRouter request failed';
+        await updateChatSession((session) => {
+          session.messages = (session.messages || []).filter((m) => !m.pending);
+          session.messages.push({ role: 'assistant', content: '\u062a\u0639\u0630\u0631 \u062a\u0648\u0644\u064a\u062f \u0627\u0644\u0631\u062f: ' + errorMsg });
+        });
+        sendResponse({ success: false, error: errorMsg });
       });
     return true;
   }

--- a/bg/message-handler.js
+++ b/bg/message-handler.js
@@ -89,6 +89,34 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return false;
   }
 
+  if (message.action === 'generateOpenRouterProposal') {
+    generateOpenRouterProposal(message)
+      .then((result) => sendResponse({ success: true, ...result }))
+      .catch((error) => {
+        console.error('OpenRouter generation error:', error);
+        sendResponse({ success: false, error: error.message || 'OpenRouter request failed' });
+      });
+    return true;
+  }
+
+  if (message.action === 'openAiPopup') {
+    chrome.storage.local.set({ popupActiveTab: 'ai-chat' }, async () => {
+      try {
+        if (chrome.action && chrome.action.openPopup) {
+          await chrome.action.openPopup();
+          sendResponse({ success: true });
+          return;
+        }
+
+        sendResponse({ success: false, error: 'Popup API unavailable' });
+      } catch (error) {
+        console.error('Open popup error:', error);
+        sendResponse({ success: false, error: error.message || 'Failed to open popup' });
+      }
+    });
+    return true;
+  }
+
   if (message.action === 'download_media') {
     const { url, filename, content } = message;
 

--- a/bg/message-handler.js
+++ b/bg/message-handler.js
@@ -108,16 +108,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     let lastFlush = 0;
     let flushTimer = null;
     let flushInFlight = Promise.resolve();
+    let finalized = false;
 
     const flushChunk = (text) => {
+      if (finalized) return;
       lastFlush = Date.now();
       flushInFlight = flushInFlight.then(async () => {
+        if (finalized) return;
         try {
           await updateChatSession((session) => {
-            const msgs = session.messages || [];
-            const pendingIdx = msgs.findIndex((m) => m.pending);
+            if (!session.messages) session.messages = [];
+            const pendingIdx = session.messages.findIndex((m) => m.pending);
             if (pendingIdx !== -1) {
-              msgs[pendingIdx] = { role: 'assistant', content: text, pending: true };
+              session.messages[pendingIdx] = { role: 'assistant', content: text, pending: true };
             }
           });
         } catch (e) {
@@ -127,6 +130,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     };
 
     const onChunk = (accumulated) => {
+      if (finalized) return;
       const now = Date.now();
       if (now - lastFlush >= STREAM_FLUSH_MS) {
         flushChunk(accumulated);
@@ -139,6 +143,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     };
 
     const finalize = async (result) => {
+      finalized = true;
       if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
       await flushInFlight;
       await updateChatSession((session) => {
@@ -150,6 +155,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     };
 
     const fail = async (error) => {
+      finalized = true;
       if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
       await flushInFlight;
       console.error('OpenRouter generation error:', error);

--- a/bg/message-handler.js
+++ b/bg/message-handler.js
@@ -107,14 +107,21 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     const STREAM_FLUSH_MS = 300;
     let lastFlush = 0;
     let flushTimer = null;
+    let flushInFlight = Promise.resolve();
 
-    const flushChunk = async (text) => {
+    const flushChunk = (text) => {
       lastFlush = Date.now();
-      await updateChatSession((session) => {
-        const msgs = session.messages || [];
-        const pendingIdx = msgs.findIndex((m) => m.pending);
-        if (pendingIdx !== -1) {
-          msgs[pendingIdx] = { role: 'assistant', content: text, pending: true };
+      flushInFlight = flushInFlight.then(async () => {
+        try {
+          await updateChatSession((session) => {
+            const msgs = session.messages || [];
+            const pendingIdx = msgs.findIndex((m) => m.pending);
+            if (pendingIdx !== -1) {
+              msgs[pendingIdx] = { role: 'assistant', content: text, pending: true };
+            }
+          });
+        } catch (e) {
+          console.error('Failed to flush OpenRouter chunk to storage:', e);
         }
       });
     };
@@ -133,6 +140,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     const finalize = async (result) => {
       if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+      await flushInFlight;
       await updateChatSession((session) => {
         session.messages = (session.messages || []).filter((m) => !m.pending);
         session.messages.push({ role: 'assistant', content: result.text });
@@ -143,6 +151,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     const fail = async (error) => {
       if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+      await flushInFlight;
       console.error('OpenRouter generation error:', error);
       const errorMsg = error.message || 'OpenRouter request failed';
       await updateChatSession((session) => {

--- a/bg/message-handler.js
+++ b/bg/message-handler.js
@@ -147,7 +147,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       const errorMsg = error.message || 'OpenRouter request failed';
       await updateChatSession((session) => {
         session.messages = (session.messages || []).filter((m) => !m.pending);
-        session.messages.push({ role: 'assistant', content: '\u062a\u0639\u0630\u0631 \u062a\u0648\u0644\u064a\u062f \u0627\u0644\u0631\u062f: ' + errorMsg });
+        session.messages.push({
+          role: 'assistant',
+          content: '\u062a\u0639\u0630\u0631 \u062a\u0648\u0644\u064a\u062f \u0627\u0644\u0631\u062f: ' + errorMsg +
+            '\n\n\u062c\u0631\u0628 \u062a\u063a\u064a\u064a\u0631 \u0627\u0644\u0645\u0648\u062f\u064a\u0644 \u0645\u0646 \u0625\u0639\u062f\u0627\u062f\u0627\u062a \u0627\u0644\u0630\u0643\u0627\u0621 \u0641\u064a \u0644\u0648\u062d\u0629 \u0627\u0644\u062a\u062d\u0643\u0645 (Dashboard).'
+        });
       });
       sendResponse({ success: false, error: errorMsg });
     };

--- a/bg/openrouter.js
+++ b/bg/openrouter.js
@@ -53,12 +53,7 @@ function normalizeOpenRouterMessages(payload) {
   return [];
 }
 
-async function generateOpenRouterProposal(payload) {
-  const messages = normalizeOpenRouterMessages(payload);
-  if (messages.length === 0) {
-    throw new Error('Prompt is required');
-  }
-
+async function getOpenRouterSettings() {
   const data = await chrome.storage.local.get(['settings']);
   const settings = data.settings || {};
   const apiKey = (settings.openRouterApiKey || '').trim();
@@ -67,6 +62,20 @@ async function generateOpenRouterProposal(payload) {
   if (!apiKey) {
     throw new Error('OpenRouter API key is missing. Add it from the dashboard settings.');
   }
+
+  return { apiKey, model };
+}
+
+/**
+ * Non-streaming request (kept as fallback).
+ */
+async function generateOpenRouterProposal(payload) {
+  const messages = normalizeOpenRouterMessages(payload);
+  if (messages.length === 0) {
+    throw new Error('Prompt is required');
+  }
+
+  const { apiKey, model } = await getOpenRouterSettings();
 
   const response = await fetch(OPENROUTER_API_URL, {
     method: 'POST',
@@ -112,6 +121,110 @@ async function generateOpenRouterProposal(payload) {
     text,
     model: result.model || model,
     usage: result.usage || null,
+    provider: 'openrouter'
+  };
+}
+
+/**
+ * Streaming request — calls onChunk(accumulatedText) as tokens arrive.
+ * Returns the final result object on completion.
+ */
+async function generateOpenRouterProposalStream(payload, onChunk) {
+  const messages = normalizeOpenRouterMessages(payload);
+  if (messages.length === 0) {
+    throw new Error('Prompt is required');
+  }
+
+  const { apiKey, model } = await getOpenRouterSettings();
+
+  const response = await fetch(OPENROUTER_API_URL, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://github.com/Elaraby218/Frelancia',
+      'X-Title': 'Frelancia'
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      temperature: 0.7,
+      stream: true
+    })
+  });
+
+  if (!response.ok) {
+    let errorMessage = `OpenRouter request failed with status ${response.status}`;
+    try {
+      const errorBody = await response.json();
+      if (errorBody && errorBody.error && errorBody.error.message) {
+        errorMessage = errorBody.error.message;
+      }
+    } catch (_) { /* ignore parse errors */ }
+    throw new Error(errorMessage);
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let accumulated = '';
+  let responseModel = model;
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    // Keep the last potentially incomplete line in the buffer
+    buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || !trimmed.startsWith('data: ')) continue;
+
+      const jsonStr = trimmed.slice(6);
+      if (jsonStr === '[DONE]') continue;
+
+      try {
+        const chunk = JSON.parse(jsonStr);
+        if (chunk.model) responseModel = chunk.model;
+
+        const delta = chunk.choices && chunk.choices[0] && chunk.choices[0].delta;
+        if (delta && delta.content) {
+          accumulated += delta.content;
+          if (onChunk) onChunk(accumulated);
+        }
+      } catch (_) {
+        // Skip malformed SSE lines
+      }
+    }
+  }
+
+  // Process any remaining buffer
+  if (buffer.trim()) {
+    const trimmed = buffer.trim();
+    if (trimmed.startsWith('data: ') && trimmed.slice(6) !== '[DONE]') {
+      try {
+        const chunk = JSON.parse(trimmed.slice(6));
+        if (chunk.model) responseModel = chunk.model;
+        const delta = chunk.choices && chunk.choices[0] && chunk.choices[0].delta;
+        if (delta && delta.content) {
+          accumulated += delta.content;
+          if (onChunk) onChunk(accumulated);
+        }
+      } catch (_) { /* ignore */ }
+    }
+  }
+
+  if (!accumulated.trim()) {
+    throw new Error('OpenRouter returned an empty response.');
+  }
+
+  return {
+    text: accumulated.trim(),
+    model: responseModel,
+    usage: null,
     provider: 'openrouter'
   };
 }

--- a/bg/openrouter.js
+++ b/bg/openrouter.js
@@ -1,0 +1,117 @@
+// ==========================================
+// bg/openrouter.js - OpenRouter API integration
+// Depends on: chrome.storage
+// ==========================================
+
+const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
+const OPENROUTER_DEFAULT_MODEL = 'openai/gpt-4o-mini';
+
+function extractOpenRouterMessageContent(message) {
+  if (!message) return '';
+
+  if (typeof message.content === 'string') {
+    return message.content.trim();
+  }
+
+  if (Array.isArray(message.content)) {
+    return message.content
+      .map((part) => {
+        if (!part) return '';
+        if (typeof part === 'string') return part;
+        if (typeof part.text === 'string') return part.text;
+        return '';
+      })
+      .join('\n')
+      .trim();
+  }
+
+  return '';
+}
+
+function normalizeOpenRouterMessages(payload) {
+  if (Array.isArray(payload) && payload.length > 0) {
+    return payload
+      .filter((message) => message && typeof message.role === 'string' && typeof message.content === 'string' && message.content.trim())
+      .map((message) => ({
+        role: message.role,
+        content: message.content.trim()
+      }));
+  }
+
+  if (payload && typeof payload === 'object' && Array.isArray(payload.messages)) {
+    return normalizeOpenRouterMessages(payload.messages);
+  }
+
+  if (payload && typeof payload === 'object' && typeof payload.prompt === 'string' && payload.prompt.trim()) {
+    return [{ role: 'user', content: payload.prompt.trim() }];
+  }
+
+  if (typeof payload === 'string' && payload.trim()) {
+    return [{ role: 'user', content: payload.trim() }];
+  }
+
+  return [];
+}
+
+async function generateOpenRouterProposal(payload) {
+  const messages = normalizeOpenRouterMessages(payload);
+  if (messages.length === 0) {
+    throw new Error('Prompt is required');
+  }
+
+  const data = await chrome.storage.local.get(['settings']);
+  const settings = data.settings || {};
+  const apiKey = (settings.openRouterApiKey || '').trim();
+  const model = (settings.openRouterModel || OPENROUTER_DEFAULT_MODEL).trim();
+
+  if (!apiKey) {
+    throw new Error('OpenRouter API key is missing. Add it from the dashboard settings.');
+  }
+
+  const response = await fetch(OPENROUTER_API_URL, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://github.com/Elaraby218/Frelancia',
+      'X-Title': 'Frelancia'
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      temperature: 0.7,
+      stream: false
+    })
+  });
+
+  let result = null;
+  try {
+    result = await response.json();
+  } catch (error) {
+    if (!response.ok) {
+      throw new Error(`OpenRouter request failed with status ${response.status}`);
+    }
+    throw error;
+  }
+
+  if (!response.ok) {
+    const errorMessage = result && result.error && result.error.message
+      ? result.error.message
+      : `OpenRouter request failed with status ${response.status}`;
+    throw new Error(errorMessage);
+  }
+
+  const choice = result && Array.isArray(result.choices) ? result.choices[0] : null;
+  const text = extractOpenRouterMessageContent(choice && choice.message);
+
+  if (!text) {
+    throw new Error('OpenRouter returned an empty response.');
+  }
+
+  return {
+    text,
+    model: result.model || model,
+    usage: result.usage || null,
+    provider: 'openrouter'
+  };
+}

--- a/bg/openrouter.js
+++ b/bg/openrouter.js
@@ -4,7 +4,7 @@
 // ==========================================
 
 const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions';
-const OPENROUTER_DEFAULT_MODEL = 'openai/gpt-4o-mini';
+const OPENROUTER_DEFAULT_MODEL = 'openrouter/hunter-alpha';
 
 function extractOpenRouterMessageContent(message) {
   if (!message) return '';
@@ -104,8 +104,10 @@ async function generateOpenRouterProposal(payload) {
   }
 
   if (!response.ok) {
-    const errorMessage = result && result.error && result.error.message
-      ? result.error.message
+    console.error('OpenRouter error response:', JSON.stringify(result, null, 2));
+    const err = result && result.error;
+    const errorMessage = err
+      ? `${err.message || 'Unknown error'}${err.code ? ' (' + err.code + ')' : ''}${err.metadata ? ' — ' + JSON.stringify(err.metadata) : ''}`
       : `OpenRouter request failed with status ${response.status}`;
     throw new Error(errorMessage);
   }
@@ -157,8 +159,10 @@ async function generateOpenRouterProposalStream(payload, onChunk) {
     let errorMessage = `OpenRouter request failed with status ${response.status}`;
     try {
       const errorBody = await response.json();
-      if (errorBody && errorBody.error && errorBody.error.message) {
-        errorMessage = errorBody.error.message;
+      console.error('OpenRouter stream error response:', JSON.stringify(errorBody, null, 2));
+      const err = errorBody && errorBody.error;
+      if (err) {
+        errorMessage = `${err.message || 'Unknown error'}${err.code ? ' (' + err.code + ')' : ''}${err.metadata ? ' — ' + JSON.stringify(err.metadata) : ''}`;
       }
     } catch (_) { /* ignore parse errors */ }
     throw new Error(errorMessage);

--- a/content/autofill.js
+++ b/content/autofill.js
@@ -8,6 +8,12 @@ function checkForAutofill() {
     handleAutofillSequence();
 }
 
+chrome.storage.onChanged.addListener((changes, areaName) => {
+    if (areaName !== 'local' || !changes.mostaql_pending_autofill) return;
+    if (!changes.mostaql_pending_autofill.newValue) return;
+    handleAutofillSequence();
+});
+
 function handleAutofillSequence() {
     if (!isContextValid()) return;
 

--- a/content/project-sidebar.js
+++ b/content/project-sidebar.js
@@ -240,52 +240,46 @@ function setButtonUntracked(btn) {
     btn.title = 'مراقبة هذا المشروع';
 }
 
-function handleChatGptClick(promptId) {
-    if (!isContextValid()) {
-        console.warn('Mostaql Ext: Extension context invalidated. Please refresh the page.');
-        return;
-    }
-    console.log('handleChatGptClick called with ID:', promptId);
-
+function buildPromptFromTemplate(promptId, callback) {
     const projectData = extractProjectData();
     const description = getProjectDescription();
-
-    console.log('--- Mostaql Ext Data Debug ---');
-    console.log('Title:', projectData.title);
-    console.log('URL:', projectData.url);
-    console.log('Description:', description);
-    console.log('Tags:', projectData.tags);
-    console.log('Client Name:', projectData.clientName);
-    console.log('Budget:', projectData.budget);
-    console.log('Duration:', projectData.duration);
-    console.log('Publish Date:', projectData.publishDate);
-    console.log('Status:', projectData.status);
-    console.log('Project ID:', projectData.id);
-    console.log('Category:', projectData.category);
-    console.log('Hiring Rate:', projectData.hiringRate);
-    console.log('Open Projects:', projectData.openProjects);
-    console.log('Underway Projects:', projectData.underwayProjects);
-    console.log('Client Joined:', projectData.clientJoined);
-    console.log('Client Type:', projectData.clientType);
-    console.log('Communications:', projectData.communications);
-    console.log('------------------------------');
 
     if (!description) {
         alert('لم يتم العثور على وصف المشروع.');
         return;
     }
 
+    const processTemplate = (content) => {
+        const prompt = content
+            .replace(/{title}/g, projectData.title)
+            .replace(/{url}/g, projectData.url)
+            .replace(/{description}/g, description)
+            .replace(/{tags}/g, projectData.tags)
+            .replace(/{client_name}/g, projectData.clientName)
+            .replace(/{budget}/g, projectData.budget)
+            .replace(/{duration}/g, projectData.duration)
+            .replace(/{publish_date}/g, projectData.publishDate)
+            .replace(/{project_status}/g, projectData.status)
+            .replace(/{project_id}/g, projectData.id)
+            .replace(/{category}/g, projectData.category)
+            .replace(/{hiring_rate}/g, projectData.hiringRate)
+            .replace(/{open_projects}/g, projectData.openProjects)
+            .replace(/{underway_projects}/g, projectData.underwayProjects)
+            .replace(/{client_joined}/g, projectData.clientJoined)
+            .replace(/{client_type}/g, projectData.clientType);
+
+        callback({ prompt, projectData, description });
+    };
+
     loadPrompts((prompts) => {
-        let templateContent = '';
         const selectedPrompt = prompts.find(p => p.id === promptId);
-        console.log('Prompts loaded:', prompts.length);
-        console.log('Selected prompt found:', !!selectedPrompt);
 
         if (selectedPrompt) {
-            templateContent = selectedPrompt.content;
-            processTemplate(templateContent);
-        } else if (promptId === 'default_proposal') {
-            console.warn('Default prompt not modified/found locally, fetching original default.');
+            processTemplate(selectedPrompt.content);
+            return;
+        }
+
+        if (promptId === 'default_proposal') {
             chrome.runtime.sendMessage({ action: 'getDefaultPrompts' }, (response) => {
                 const defaults = (response && response.prompts) ? response.prompts : [];
                 const def = defaults.find(d => d.id === 'default_proposal');
@@ -296,38 +290,68 @@ function handleChatGptClick(promptId) {
                 }
             });
             return;
-        } else {
-            console.error('Prompt ID not found:', promptId);
-            alert('خطأ: لم يتم العثور على القالب المحدد (ID: ' + promptId + '). تحقق من قائمة الأوامر.');
-            return;
         }
 
-        function processTemplate(content) {
-            let prompt = content
-                .replace(/{title}/g, projectData.title)
-                .replace(/{url}/g, projectData.url)
-                .replace(/{description}/g, description)
-                .replace(/{tags}/g, projectData.tags)
-                .replace(/{client_name}/g, projectData.clientName)
-                .replace(/{budget}/g, projectData.budget)
-                .replace(/{duration}/g, projectData.duration)
-                .replace(/{publish_date}/g, projectData.publishDate)
-                .replace(/{project_status}/g, projectData.status)
-                .replace(/{project_id}/g, projectData.id)
-                .replace(/{category}/g, projectData.category)
-                .replace(/{hiring_rate}/g, projectData.hiringRate)
-                .replace(/{open_projects}/g, projectData.openProjects)
-                .replace(/{underway_projects}/g, projectData.underwayProjects)
-                .replace(/{client_joined}/g, projectData.clientJoined)
-                .replace(/{client_type}/g, projectData.clientType);
+        alert('خطأ: لم يتم العثور على القالب المحدد (ID: ' + promptId + '). تحقق من قائمة الأوامر.');
+    });
+}
 
-            chrome.storage.local.set({ 'pendingChatGptPrompt': prompt }, () => {
-                chrome.storage.local.get(['settings'], (result) => {
-                    const settings = result.settings || {};
-                    const url = settings.aiChatUrl || 'https://chatgpt.com/';
-                    window.open(url, 'mostaql_ai_chat');
-                });
-            });
+function openChatGptPrompt(prompt, settings) {
+    chrome.storage.local.set({ pendingChatGptPrompt: prompt }, () => {
+        const url = settings.aiChatUrl || 'https://chatgpt.com/';
+        window.open(url, 'mostaql_ai_chat');
+    });
+}
+
+function openOpenRouterChat(prompt, projectData, promptId) {
+    const chatState = {
+        createdAt: Date.now(),
+        promptId: promptId,
+        initialPrompt: String(prompt || '').trim(),
+        project: {
+            id: projectData.id,
+            title: projectData.title,
+            url: projectData.url,
+            budget: projectData.budget,
+            duration: projectData.duration,
+            clientName: projectData.clientName
         }
+    };
+
+    chrome.storage.local.set({
+        openRouterPendingChat: chatState,
+        openRouterChatSession: null,
+        popupActiveTab: 'ai-chat'
+    }, () => {
+        chrome.runtime.sendMessage({ action: 'openAiPopup' }, (response) => {
+            if (chrome.runtime.lastError) {
+                console.error('Failed to open AI popup:', chrome.runtime.lastError.message);
+            }
+        });
+    });
+}
+
+function handleChatGptClick(promptId) {
+    if (!isContextValid()) {
+        console.warn('Mostaql Ext: Extension context invalidated. Please refresh the page.');
+        return;
+    }
+
+    buildPromptFromTemplate(promptId, ({ prompt, projectData }) => {
+        chrome.storage.local.get(['settings'], (result) => {
+            const settings = result.settings || {};
+            const provider = settings.aiProvider || 'chatgpt';
+
+            if (provider === 'openrouter') {
+                if (!settings.openRouterApiKey) {
+                    alert('يرجى إضافة مفتاح OpenRouter API من لوحة التحكم ثم حفظ الإعدادات.');
+                    return;
+                }
+                openOpenRouterChat(prompt, projectData, promptId);
+                return;
+            }
+
+            openChatGptPrompt(prompt, settings);
+        });
     });
 }

--- a/dashboard.css
+++ b/dashboard.css
@@ -323,6 +323,59 @@ body {
     font-weight: 500;
 }
 
+.inline-input-row {
+    display: flex;
+    gap: 12px;
+    align-items: stretch;
+}
+
+.inline-input-row .form-control {
+    flex: 1;
+}
+
+.compact-btn {
+    padding: 0 18px;
+    min-width: 110px;
+    justify-content: center;
+    white-space: nowrap;
+}
+
+.provider-card {
+    background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 100%);
+    border: 1px solid #d8e7ff;
+    border-radius: var(--radius-md);
+    padding: 20px;
+    margin-bottom: 24px;
+}
+
+.provider-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.provider-card-header strong {
+    display: block;
+    font-size: 16px;
+    color: var(--text-title);
+}
+
+.provider-card-header .help-text {
+    margin-top: 6px;
+}
+
+.provider-badge {
+    background: #dbeafe;
+    color: #1d4ed8;
+    border-radius: 999px;
+    padding: 6px 12px;
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+}
+
 /* Toggles */
 .toggle-row {
     display: flex;

--- a/dashboard.html
+++ b/dashboard.html
@@ -332,12 +332,66 @@
                     <div class="settings-section">
                         <div class="section-header">
                             <i class="fas fa-robot"></i>
-                            <h3>رابط الذكاء الاصطناعي</h3>
+                            <h3>تكامل الذكاء الاصطناعي</h3>
                         </div>
                         <div class="form-group">
-                            <label>رابط الشات المفضل</label>
-                            <input type="text" id="aiChatUrl" class="form-control" placeholder="https://chatgpt.com/" dir="ltr">
-                            <p class="help-text">يمكنك استخدام رابط مخصص أو رابط مشروع ChatGPT بعينه.</p>
+                            <label>مزود الذكاء الاصطناعي</label>
+                            <select id="aiProvider" class="form-control">
+                                <option value="chatgpt">ChatGPT (الطريقة الحالية)</option>
+                                <option value="openrouter">OpenRouter API</option>
+                            </select>
+                            <p class="help-text">يمكنك التبديل بين فتح ChatGPT تلقائياً أو توليد العرض مباشرة عبر OpenRouter بنفس القوالب الحالية.</p>
+                        </div>
+                        <div id="chatgptSettingsGroup">
+                            <div class="form-group">
+                                <label>رابط الشات المفضل</label>
+                                <input type="text" id="aiChatUrl" class="form-control" placeholder="https://chatgpt.com/" dir="ltr">
+                                <p class="help-text">يمكنك استخدام رابط مخصص أو رابط مشروع ChatGPT بعينه.</p>
+                            </div>
+                        </div>
+                        <div id="openRouterSettingsGroup" class="hidden">
+                            <div class="provider-card">
+                                <div class="provider-card-header">
+                                    <div>
+                                        <strong>OpenRouter API</strong>
+                                        <p class="help-text">نفس القوالب الحالية، لكن التوليد يتم داخل الإضافة مباشرة بدون الاعتماد على أتمتة ChatGPT.</p>
+                                    </div>
+                                    <span class="provider-badge">API</span>
+                                </div>
+                                <div class="form-group">
+                                    <label>مفتاح OpenRouter API</label>
+                                    <div class="inline-input-row">
+                                        <input type="password" id="openRouterApiKey" class="form-control" placeholder="sk-or-v1-..." dir="ltr" autocomplete="off">
+                                        <button type="button" id="toggleOpenRouterApiKey" class="btn-secondary compact-btn">
+                                            <i class="fas fa-eye"></i>
+                                            <span>إظهار</span>
+                                        </button>
+                                    </div>
+                                    <p class="help-text">يُحفظ محلياً داخل Chrome Storage فقط، ويُستخدم لإرسال نفس الـ prompt إلى OpenRouter.</p>
+                                </div>
+                                <div class="form-group">
+                                    <label>قائمة الموديلات المجانية الشائعة</label>
+                                    <select id="openRouterModelPreset" class="form-control" dir="ltr">
+                                        <option value="">اختر موديل مجاني شائع...</option>
+                                        <option value="meta-llama/llama-3.3-70b-instruct:free">Meta: Llama 3.3 70B Instruct (free)</option>
+                                        <option value="mistralai/mistral-small-3.1-24b-instruct:free">Mistral: Mistral Small 3.1 24B (free)</option>
+                                        <option value="google/gemma-3-27b-it:free">Google: Gemma 3 27B (free)</option>
+                                        <option value="google/gemma-3-12b-it:free">Google: Gemma 3 12B (free)</option>
+                                        <option value="qwen/qwen3-next-80b-a3b-instruct:free">Qwen: Qwen3 Next 80B A3B Instruct (free)</option>
+                                        <option value="z-ai/glm-4.5-air:free">Z.ai: GLM 4.5 Air (free)</option>
+                                        <option value="openai/gpt-oss-120b:free">OpenAI: gpt-oss-120b (free)</option>
+                                        <option value="openai/gpt-oss-20b:free">OpenAI: gpt-oss-20b (free)</option>
+                                        <option value="minimax/minimax-m2.5:free">MiniMax: MiniMax M2.5 (free)</option>
+                                        <option value="nousresearch/hermes-3-llama-3.1-405b:free">Nous: Hermes 3 405B Instruct (free)</option>
+                                    </select>
+                                    <p class="help-text">تم اختيار هذه الأسماء بعد التحقق من معرفات موديلات OpenRouter المجانية الحالية.</p>
+                                </div>
+                                <div class="form-group">
+                                    <label>اسم الموديل</label>
+                                    <input type="text" id="openRouterModel" class="form-control" placeholder="openai/gpt-4o-mini" dir="ltr">
+                                    <p class="help-text">أدخل أي موديل متاح في OpenRouter. الافتراضي: <code>openai/gpt-4o-mini</code>.</p>
+                                </div>
+                            </div>
                         </div>
                         <div class="form-group">
                             <label>تكرار الفحص (بالدقائق)</label>

--- a/dashboard.html
+++ b/dashboard.html
@@ -388,8 +388,8 @@
                                 </div>
                                 <div class="form-group">
                                     <label>اسم الموديل</label>
-                                    <input type="text" id="openRouterModel" class="form-control" placeholder="openai/gpt-4o-mini" dir="ltr">
-                                    <p class="help-text">أدخل أي موديل متاح في OpenRouter. الافتراضي: <code>openai/gpt-4o-mini</code>.</p>
+                                    <input type="text" id="openRouterModel" class="form-control" placeholder="openrouter/hunter-alpha" dir="ltr">
+                                    <p class="help-text">أدخل أي موديل متاح في OpenRouter. الافتراضي: <code>openrouter/hunter-alpha</code>.</p>
                                 </div>
                             </div>
                         </div>

--- a/dashboard/events.js
+++ b/dashboard/events.js
@@ -31,6 +31,26 @@ function setupEventListeners() {
         saveBtn.addEventListener('click', saveAllSettings);
     }
 
+    const aiProvider = document.getElementById('aiProvider');
+    if (aiProvider) {
+        aiProvider.addEventListener('change', syncAiProviderFields);
+    }
+
+    const toggleApiKeyBtn = document.getElementById('toggleOpenRouterApiKey');
+    if (toggleApiKeyBtn) {
+        toggleApiKeyBtn.addEventListener('click', toggleOpenRouterApiKeyVisibility);
+    }
+
+    const openRouterModelPreset = document.getElementById('openRouterModelPreset');
+    if (openRouterModelPreset) {
+        openRouterModelPreset.addEventListener('change', applyOpenRouterModelPreset);
+    }
+
+    const openRouterModel = document.getElementById('openRouterModel');
+    if (openRouterModel) {
+        openRouterModel.addEventListener('input', syncOpenRouterModelPreset);
+    }
+
     // Prompt modal — open
     const addPromptBtn = document.getElementById('addPromptBtn');
     if (addPromptBtn) addPromptBtn.addEventListener('click', () => openPromptModal());

--- a/dashboard/settings.js
+++ b/dashboard/settings.js
@@ -20,7 +20,7 @@ function saveAllSettings() {
         aiProvider:       getVal('aiProvider') || 'chatgpt',
         aiChatUrl:        getVal('aiChatUrl'),
         openRouterApiKey: getVal('openRouterApiKey'),
-        openRouterModel:  getVal('openRouterModel') || 'openai/gpt-4o-mini',
+        openRouterModel:  getVal('openRouterModel') || 'openrouter/hunter-alpha',
         quietHoursEnabled: getVal('quietHoursEnabled'),
         quietHoursStart:  getVal('quietHoursStart'),
         quietHoursEnd:    getVal('quietHoursEnd'),
@@ -69,7 +69,7 @@ function applySettingsToForm(s) {
     setVal('aiProvider',        s.aiProvider || 'chatgpt');
     setVal('aiChatUrl',         s.aiChatUrl || 'https://chatgpt.com/');
     setVal('openRouterApiKey',  s.openRouterApiKey || '');
-    setVal('openRouterModel',   s.openRouterModel || 'openai/gpt-4o-mini');
+    setVal('openRouterModel',   s.openRouterModel || 'openrouter/hunter-alpha');
     setVal('openRouterModelPreset', '');
     setVal('quietHoursEnabled', s.quietHoursEnabled === true);
     setVal('quietHoursStart',   s.quietHoursStart);

--- a/dashboard/settings.js
+++ b/dashboard/settings.js
@@ -17,7 +17,10 @@ function saveAllSettings() {
         development:      getVal('cat-development'),
         ai:               getVal('cat-ai'),
         all:              getVal('cat-all'),
+        aiProvider:       getVal('aiProvider') || 'chatgpt',
         aiChatUrl:        getVal('aiChatUrl'),
+        openRouterApiKey: getVal('openRouterApiKey'),
+        openRouterModel:  getVal('openRouterModel') || 'openai/gpt-4o-mini',
         quietHoursEnabled: getVal('quietHoursEnabled'),
         quietHoursStart:  getVal('quietHoursStart'),
         quietHoursEnd:    getVal('quietHoursEnd'),
@@ -63,7 +66,11 @@ function applySettingsToForm(s) {
     setVal('cat-development',   s.development !== false);
     setVal('cat-ai',            s.ai !== false);
     setVal('cat-all',           s.all !== false);
+    setVal('aiProvider',        s.aiProvider || 'chatgpt');
     setVal('aiChatUrl',         s.aiChatUrl || 'https://chatgpt.com/');
+    setVal('openRouterApiKey',  s.openRouterApiKey || '');
+    setVal('openRouterModel',   s.openRouterModel || 'openai/gpt-4o-mini');
+    setVal('openRouterModelPreset', '');
     setVal('quietHoursEnabled', s.quietHoursEnabled === true);
     setVal('quietHoursStart',   s.quietHoursStart);
     setVal('quietHoursEnd',     s.quietHoursEnd);
@@ -71,4 +78,50 @@ function applySettingsToForm(s) {
     setVal('systemToggle',      s.systemEnabled !== false);
     setVal('notificationMode',  s.notificationMode || 'auto');
     setVal('signalrServerUrl',  s.signalrServerUrl || '');
+
+    syncAiProviderFields();
+    syncOpenRouterModelPreset();
+}
+
+function syncAiProviderFields() {
+    const provider = document.getElementById('aiProvider')?.value || 'chatgpt';
+    const chatgptGroup = document.getElementById('chatgptSettingsGroup');
+    const openRouterGroup = document.getElementById('openRouterSettingsGroup');
+
+    if (chatgptGroup) {
+        chatgptGroup.classList.toggle('hidden', provider !== 'chatgpt');
+    }
+
+    if (openRouterGroup) {
+        openRouterGroup.classList.toggle('hidden', provider !== 'openrouter');
+    }
+}
+
+function toggleOpenRouterApiKeyVisibility() {
+    const input = document.getElementById('openRouterApiKey');
+    const button = document.getElementById('toggleOpenRouterApiKey');
+    if (!input || !button) return;
+
+    const isPassword = input.type === 'password';
+    input.type = isPassword ? 'text' : 'password';
+    button.innerHTML = isPassword
+        ? '<i class="fas fa-eye-slash"></i><span>إخفاء</span>'
+        : '<i class="fas fa-eye"></i><span>إظهار</span>';
+}
+
+function syncOpenRouterModelPreset() {
+    const preset = document.getElementById('openRouterModelPreset');
+    const input = document.getElementById('openRouterModel');
+    if (!preset || !input) return;
+
+    const matchingOption = Array.from(preset.options).find((option) => option.value && option.value === input.value);
+    preset.value = matchingOption ? matchingOption.value : '';
+}
+
+function applyOpenRouterModelPreset() {
+    const preset = document.getElementById('openRouterModelPreset');
+    const input = document.getElementById('openRouterModel');
+    if (!preset || !input || !preset.value) return;
+
+    input.value = preset.value;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,13 +8,15 @@
     "alarms",
     "storage",
     "offscreen",
-    "downloads"
+    "downloads",
+    "tabs"
   ],
   "host_permissions": [
     "https://mostaql.com/*",
     "https://chatgpt.com/*",
     "https://chat.openai.com/*",
-    "https://frelancia.runasp.net/*"
+    "https://frelancia.runasp.net/*",
+    "https://openrouter.ai/*"
   ],
   "content_scripts": [
     {

--- a/popup.css
+++ b/popup.css
@@ -3,6 +3,7 @@
 :root {
   --primary: #2386c8;
   --primary-hover: #1e70a9;
+  --accent: #2386c8;
   --bg: #f6f7f9;
   --card: #ffffff;
   --text-main: #3e4751;
@@ -24,57 +25,102 @@ body {
   font-family: 'Cairo', sans-serif;
   background-color: var(--bg);
   color: var(--text-main);
-  width: 340px;
-  min-height: 420px;
+  width: 420px;
+  min-height: 620px;
   overflow: hidden;
+}
+
+.hidden {
+  display: none !important;
 }
 
 .minimal-container {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 620px;
 }
 
 .header {
   background: var(--primary);
-  padding: 24px 16px;
-  text-align: center;
+  padding: 22px 18px 14px;
   color: white;
   border-bottom: 2px solid rgba(0, 0, 0, 0.05);
 }
 
-.main-logo {
-  width: 60px;
-  height: 60px;
-  margin-bottom: 12px;
-  filter: brightness(0) invert(1);
-  /* Make logo white for blue background if needed */
-}
-
 .header h1 {
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 800;
-  margin-bottom: 2px;
 }
 
 .tagline {
   font-size: 13px;
-  opacity: 0.9;
+  opacity: 0.92;
   font-weight: 600;
+  margin-top: 2px;
+}
+
+.popup-tabs {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.popup-tab {
+  flex: 1;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.14);
+  color: white;
+  border-radius: 999px;
+  padding: 10px 14px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 700;
+}
+
+.popup-tab.active {
+  background: white;
+  color: var(--primary);
+}
+
+.popup-panel {
+  display: none;
+}
+
+.popup-panel.active {
+  display: block;
 }
 
 .content-body {
-  padding: 20px;
+  padding: 18px;
+}
+
+#ai-chat-tab {
+  display: none;
+  height: 100%;
+}
+
+#ai-chat-tab.active {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.stats-overview,
+.chat-project-card,
+.chat-messages,
+.chat-composer,
+.status-indicator,
+.chat-status-row {
+  background: var(--card);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
 }
 
 .stats-overview {
   display: flex;
-  background: var(--card);
-  border-radius: var(--radius);
   padding: 16px;
-  margin-bottom: 20px;
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow);
+  margin-bottom: 16px;
 }
 
 .stat-box {
@@ -84,7 +130,7 @@ body {
 
 .stat-num {
   display: block;
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 800;
   color: var(--primary);
 }
@@ -106,10 +152,11 @@ body {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  margin-bottom: 24px;
+  margin-bottom: 18px;
   font-size: 12px;
   font-weight: 700;
   color: var(--text-sub);
+  padding: 12px;
 }
 
 .dot {
@@ -127,13 +174,13 @@ body {
 .main-actions {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
 .btn {
   width: 100%;
-  padding: 12px;
-  border-radius: 8px;
+  padding: 12px 14px;
+  border-radius: 12px;
   border: none;
   font-family: inherit;
   font-size: 14px;
@@ -151,21 +198,16 @@ body {
   color: white;
 }
 
-.btn.primary:hover {
-  background: var(--primary-hover);
-  transform: translateY(-1px);
-}
-
 .btn.secondary {
   background: white;
   color: var(--text-main);
   border: 1px solid var(--border);
 }
 
-.btn.secondary:hover {
-  background: #f8f9fa;
-  border-color: var(--primary);
-  color: var(--primary);
+.btn.compact {
+  width: auto;
+  padding: 10px 12px;
+  font-size: 12px;
 }
 
 .btn.toggle-off {
@@ -174,32 +216,20 @@ body {
   border-color: #fbc6c6;
 }
 
-.btn.toggle-off:hover {
-  background: #fae4e4;
-  border-color: var(--danger);
-  color: var(--danger);
-}
-
-/* Connection specific */
 .btn.connection {
-  padding: 6px;
+  padding: 8px;
   font-size: 11px;
   color: var(--text-sub);
   background: transparent;
   border: 1px solid transparent;
-  margin-top: 8px;
-}
-
-.btn.connection:hover {
-  color: var(--primary);
-  border-color: var(--border);
+  margin-top: 2px;
 }
 
 .connection-report {
   font-size: 11px;
   padding: 10px;
-  border-radius: 8px;
-  margin-top: 8px;
+  border-radius: 10px;
+  margin-top: 10px;
   text-align: center;
 }
 
@@ -213,10 +243,304 @@ body {
   color: #c62828;
 }
 
+.chat-project-card {
+  padding: 14px;
+  background: linear-gradient(180deg, #ffffff 0%, #f9fcff 100%);
+}
+
+.chat-project-label {
+  font-size: 11px;
+  color: var(--text-sub);
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.chat-project-title {
+  font-size: 15px;
+  font-weight: 800;
+  line-height: 1.6;
+  max-height: 48px;
+  overflow: hidden;
+}
+
+.chat-project-meta {
+  font-size: 12px;
+  color: var(--text-sub);
+  margin-top: 6px;
+  line-height: 1.7;
+}
+
+.chat-status-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  font-size: 11px;
+  color: var(--text-sub);
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.chat-messages {
+  height: 296px;
+  padding: 12px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  scrollbar-gutter: stable;
+}
+
+.chat-messages::-webkit-scrollbar {
+  width: 8px;
+}
+
+.chat-messages::-webkit-scrollbar-thumb {
+  background: #c8d7e5;
+  border-radius: 999px;
+}
+
+.chat-empty {
+  text-align: center;
+  color: var(--text-sub);
+  font-size: 13px;
+  line-height: 1.8;
+  padding: 40px 14px;
+}
+
+.chat-message {
+  display: flex;
+}
+
+.chat-message.user {
+  justify-content: flex-start;
+}
+
+.chat-message.assistant {
+  justify-content: flex-end;
+}
+
+.chat-bubble {
+  max-width: 88%;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 11px 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.8;
+  font-size: 12px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.chat-bubble p,
+.chat-bubble ul,
+.chat-bubble h1,
+.chat-bubble h2,
+.chat-bubble h3 {
+  margin: 0 0 8px;
+}
+
+.chat-bubble p:last-child,
+.chat-bubble ul:last-child,
+.chat-bubble h1:last-child,
+.chat-bubble h2:last-child,
+.chat-bubble h3:last-child {
+  margin-bottom: 0;
+}
+
+.chat-bubble ul {
+  padding-right: 18px;
+}
+
+.chat-bubble li {
+  margin-bottom: 6px;
+}
+
+.chat-bubble h1,
+.chat-bubble h2,
+.chat-bubble h3 {
+  color: #1f4f7a;
+  line-height: 1.5;
+}
+
+.chat-bubble h1 { font-size: 16px; }
+.chat-bubble h2 { font-size: 15px; }
+.chat-bubble h3 { font-size: 14px; }
+
+.chat-bubble code {
+  background: #eef6ff;
+  color: #155a8a;
+  border-radius: 6px;
+  padding: 1px 6px;
+  font-family: Consolas, monospace;
+  font-size: 11px;
+}
+
+.chat-bubble pre {
+  background: #f7fbff;
+  border: 1px solid #d7e9f8;
+  border-radius: 10px;
+  padding: 10px 12px;
+  overflow-x: auto;
+  margin: 0 0 8px;
+}
+
+.chat-bubble pre code {
+  background: transparent;
+  color: #24425c;
+  padding: 0;
+  border-radius: 0;
+  font-size: 11px;
+  display: block;
+  line-height: 1.7;
+}
+
+.chat-bubble ol {
+  padding-right: 18px;
+  margin: 0 0 8px;
+}
+
+.chat-bubble blockquote {
+  margin: 0 0 8px;
+  padding: 8px 12px;
+  border-right: 3px solid #2386c8;
+  background: #f7fbff;
+  color: #4b5d70;
+}
+
+.chat-bubble hr {
+  border: 0;
+  border-top: 1px solid #dbe5ee;
+  margin: 10px 0;
+}
+
+.chat-bubble a {
+  color: #1e70a9;
+  text-decoration: underline;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  margin: 0 0 8px;
+}
+
+.chat-bubble table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+  background: #fff;
+}
+
+.chat-bubble th,
+.chat-bubble td {
+  border: 1px solid #dbe5ee;
+  padding: 8px 10px;
+  text-align: right;
+  vertical-align: top;
+}
+
+.chat-bubble th {
+  background: #eef6ff;
+  color: #1f4f7a;
+  font-weight: 800;
+}
+
+.chat-message.user .chat-bubble {
+  background: #f0f7ff;
+  border-color: #d7e9f8;
+}
+
+.chat-message.assistant .chat-bubble {
+  background: #ffffff;
+}
+
+.chat-role {
+  font-size: 10px;
+  color: var(--text-sub);
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.chat-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.mini-btn {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: white;
+  padding: 6px 8px;
+  font-size: 11px;
+  font-family: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.chat-composer {
+  padding: 12px;
+  background: linear-gradient(180deg, #ffffff 0%, #fbfdff 100%);
+}
+
+.chat-composer textarea {
+  width: 100%;
+  min-height: 96px;
+  resize: vertical;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  outline: none;
+  background: #f8fbff;
+  font: inherit;
+  color: var(--text-main);
+  line-height: 1.8;
+  padding: 10px;
+}
+
+.chat-composer textarea:focus {
+  border-color: rgba(35, 134, 200, 0.35);
+  background: #fff;
+}
+
+.chat-composer-actions {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.chat-composer-actions .btn.compact {
+  flex: 1 1 calc(50% - 4px);
+}
+
+.typing {
+  display: inline-flex;
+  gap: 5px;
+}
+
+.typing span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--primary);
+  animation: pulse 1s infinite ease-in-out;
+}
+
+.typing span:nth-child(2) { animation-delay: 0.15s; }
+.typing span:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes pulse {
+  0%, 80%, 100% { transform: scale(0.6); opacity: 0.45; }
+  40% { transform: scale(1); opacity: 1; }
+}
+
 .footer {
   margin-top: auto;
   text-align: center;
-  padding: 16px;
+  padding: 14px;
   border-top: 1px solid var(--border);
 }
 

--- a/popup.html
+++ b/popup.html
@@ -14,9 +14,13 @@
         <h1>Frelancia Pro</h1>
         <p class="tagline">مساعدك الذكي على مستقل</p>
       </div>
+      <div class="popup-tabs">
+        <button class="popup-tab active" data-tab="overview">الرئيسية</button>
+        <button class="popup-tab" data-tab="ai-chat">AI Chat</button>
+      </div>
     </div>
 
-    <div class="content-body">
+    <div class="content-body popup-panel active" id="overview-tab">
       <div class="stats-overview">
         <div class="stat-box">
           <span class="stat-num" id="todayCount">0</span>
@@ -57,11 +61,38 @@
       <div id="connectionReport" class="connection-report hidden"></div>
     </div>
 
+    <div class="content-body popup-panel" id="ai-chat-tab">
+      <div class="chat-project-card" id="chatProjectCard">
+        <div class="chat-project-label">المشروع الحالي</div>
+        <div class="chat-project-title" id="chatProjectTitle">بانتظار مشروع...</div>
+        <div class="chat-project-meta" id="chatProjectMeta">اضغط زر الذكاء من صفحة المشروع لبدء المحادثة هنا.</div>
+      </div>
+
+      <div class="chat-status-row">
+        <span id="chatStatus">جاهز</span>
+        <span id="chatModel">-</span>
+      </div>
+
+      <div id="chatMessages" class="chat-messages"></div>
+
+      <div class="chat-composer">
+        <textarea id="chatComposer" placeholder="اكتب تعليمات إضافية أو عدل على العرض..."></textarea>
+        <div class="chat-composer-actions">
+          <button id="newChatBtn" class="btn secondary compact">محادثة جديدة</button>
+          <button id="copyLastReplyBtn" class="btn secondary compact">نسخ آخر رد</button>
+          <button id="applyLastReplyBtn" class="btn secondary compact">تعبئة العرض</button>
+          <button id="sendChatBtn" class="btn primary compact">إرسال</button>
+        </div>
+      </div>
+    </div>
+
     <div class="footer">
       <a href="https://mostaql.com/projects" target="_blank">زيارة موقع مستقل الرسمي</a>
     </div>
   </div>
 
+  <script src="shared/markdown.js"></script>
+  <script src="shared/chat-utils.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,57 +1,83 @@
 // ==========================================
-// Frelancia | منبه مستقل - Minimal Popup Script
+// popup.js — Popup entry point
+// Depends on: shared/markdown.js, shared/chat-utils.js (loaded via <script> tags)
 // ==========================================
 
-document.addEventListener('DOMContentLoaded', () => {
-  // Initialize minimal UI
+let popupChatState = {
+  project: null,
+  messages: [],
+  model: '',
+  loading: false,
+  sessionProjectId: '',
+  contextSummary: ''
+};
+
+// ==========================================
+// Initialisation
+// ==========================================
+
+document.addEventListener('DOMContentLoaded', async () => {
   loadStats();
-  setupEventListeners();
-  
-  // Refresh stats every 30 seconds while popup is open
+  setupOverviewListeners();
+  setupChatListeners();
+  setupTabSwitching();
+  await loadPopupChatState();
   setInterval(loadStats, 30000);
 });
 
 // ==========================================
-// Load Stats
+// Tab Switching
 // ==========================================
+
+function setupTabSwitching() {
+  document.querySelectorAll('.popup-tab').forEach((button) => {
+    button.addEventListener('click', () => activateTab(button.dataset.tab));
+  });
+
+  chrome.storage.local.get(['popupActiveTab'], (data) => {
+    activateTab(data.popupActiveTab || 'overview');
+  });
+}
+
+function activateTab(tabId) {
+  document.querySelectorAll('.popup-tab').forEach((button) => {
+    button.classList.toggle('active', button.dataset.tab === tabId);
+  });
+
+  document.querySelectorAll('.popup-panel').forEach((panel) => {
+    panel.classList.toggle('active', panel.id === `${tabId}-tab`);
+  });
+
+  chrome.storage.local.set({ popupActiveTab: tabId });
+}
+
+// ==========================================
+// Overview Tab — Stats & Actions
+// ==========================================
+
 function loadStats() {
   chrome.storage.local.get(['stats', 'seenJobs'], (data) => {
     const stats = data.stats || {};
     const seenJobs = data.seenJobs || [];
 
-    // Last check time formatting
     if (stats.lastCheck) {
-      const lastCheck = new Date(stats.lastCheck);
-      const now = new Date();
-      const diffMinutes = Math.floor((now - lastCheck) / 60000);
-
+      const diffMinutes = Math.floor((Date.now() - new Date(stats.lastCheck)) / 60000);
       let timeText;
-      if (diffMinutes < 1) {
-        timeText = 'الآن';
-      } else if (diffMinutes < 60) {
-        timeText = `منذ ${diffMinutes} دقيقة`;
-      } else if (diffMinutes < 1440) {
-        timeText = `منذ ${Math.floor(diffMinutes / 60)} ساعة`;
-      } else {
-        timeText = lastCheck.toLocaleDateString('ar-SA');
-      }
-
+      if (diffMinutes < 1)        timeText = 'الآن';
+      else if (diffMinutes < 60)  timeText = `منذ ${diffMinutes} دقيقة`;
+      else if (diffMinutes < 1440) timeText = `منذ ${Math.floor(diffMinutes / 60)} ساعة`;
+      else                        timeText = new Date(stats.lastCheck).toLocaleDateString('ar-SA');
       document.getElementById('lastCheck').textContent = `آخر فحص: ${timeText}`;
     } else {
       document.getElementById('lastCheck').textContent = 'لم يتم الفحص بعد';
     }
 
-    // Update counts
     document.getElementById('todayCount').textContent = stats.todayCount || 0;
     document.getElementById('totalSeen').textContent = seenJobs.length;
   });
 }
 
-// ==========================================
-// Event Listeners
-// ==========================================
-function setupEventListeners() {
-  // Open Dashboard
+function setupOverviewListeners() {
   const dashboardBtn = document.getElementById('open-dashboard-btn');
   if (dashboardBtn) {
     dashboardBtn.addEventListener('click', (e) => {
@@ -60,15 +86,14 @@ function setupEventListeners() {
     });
   }
 
-  // Check Now
   const checkBtn = document.getElementById('checkNowBtn');
   if (checkBtn) {
     checkBtn.addEventListener('click', () => {
       const originalContent = checkBtn.innerHTML;
       checkBtn.disabled = true;
       checkBtn.innerHTML = '<span>جاري الفحص...</span>';
-      
-      chrome.runtime.sendMessage({ action: 'checkNow' }, (response) => {
+
+      chrome.runtime.sendMessage({ action: 'checkNow' }, () => {
         checkBtn.disabled = false;
         checkBtn.innerHTML = originalContent;
         loadStats();
@@ -76,7 +101,6 @@ function setupEventListeners() {
     });
   }
 
-  // Check Connection (Diagnostics)
   const connBtn = document.getElementById('checkConnectionBtn');
   const connReport = document.getElementById('connectionReport');
   if (connBtn) {
@@ -102,20 +126,15 @@ function setupEventListeners() {
     });
   }
 
-  // Toggle Notifications
   const toggleBtn = document.getElementById('toggleNotificationsBtn');
   if (toggleBtn) {
-    // Load initial state
     chrome.storage.local.get(['notificationsEnabled'], (data) => {
-      const isEnabled = data.notificationsEnabled !== false; // Default to true
-      updateToggleUI(toggleBtn, isEnabled);
+      updateToggleUI(toggleBtn, data.notificationsEnabled !== false);
     });
 
     toggleBtn.addEventListener('click', () => {
       chrome.storage.local.get(['notificationsEnabled'], (data) => {
-        const isEnabled = data.notificationsEnabled !== false;
-        const newState = !isEnabled;
-        
+        const newState = !(data.notificationsEnabled !== false);
         chrome.storage.local.set({ notificationsEnabled: newState }, () => {
           updateToggleUI(toggleBtn, newState);
         });
@@ -124,9 +143,6 @@ function setupEventListeners() {
   }
 }
 
-// ==========================================
-// Helper: Update Toggle UI
-// ==========================================
 function updateToggleUI(button, isEnabled) {
   if (isEnabled) {
     button.className = 'btn secondary';
@@ -134,5 +150,272 @@ function updateToggleUI(button, isEnabled) {
   } else {
     button.className = 'btn toggle-off';
     button.innerHTML = '<i class="fas fa-bell-slash"></i><span>الإشعارات: متوقفة</span>';
+  }
+}
+
+// ==========================================
+// AI Chat Tab — State Management
+// ==========================================
+
+function setupChatListeners() {
+  document.getElementById('sendChatBtn')?.addEventListener('click', sendChatMessage);
+  document.getElementById('newChatBtn')?.addEventListener('click', clearChat);
+  document.getElementById('copyLastReplyBtn')?.addEventListener('click', () => {
+    const msg = getLastAssistantMessage();
+    if (msg) copyToClipboard(msg.content);
+  });
+  document.getElementById('applyLastReplyBtn')?.addEventListener('click', () => {
+    const msg = getLastAssistantMessage();
+    if (msg) applyProposalToProject(msg.content);
+  });
+
+  document.getElementById('chatComposer')?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendChatMessage();
+    }
+  });
+
+  chrome.storage.onChanged.addListener(async (changes, areaName) => {
+    if (areaName !== 'local') return;
+
+    if (changes[CHAT_PENDING_KEY]?.newValue) {
+      await loadPopupChatState();
+      activateTab('ai-chat');
+    }
+
+    if (changes.popupActiveTab?.newValue === 'ai-chat') {
+      activateTab('ai-chat');
+    }
+  });
+}
+
+function setChatStatus(text) {
+  document.getElementById('chatStatus').textContent = text;
+}
+
+function resetChatForProject(project, initialPrompt) {
+  popupChatState.project = project || null;
+  popupChatState.sessionProjectId = project?.id || '';
+  popupChatState.contextSummary = buildProjectContextSummary(project);
+  const prompt = String(initialPrompt || '').trim();
+  popupChatState.messages = prompt ? [{ role: 'user', content: prompt }] : [];
+}
+
+function getLastAssistantMessage() {
+  const replies = popupChatState.messages.filter((m) => m.role === 'assistant' && !m.pending && m.content);
+  return replies.length ? replies[replies.length - 1] : null;
+}
+
+// ==========================================
+// AI Chat Tab — Persistence
+// ==========================================
+
+async function persistPopupChatState() {
+  await chrome.storage.local.set({
+    [CHAT_STORAGE_KEY]: {
+      project: popupChatState.project,
+      messages: popupChatState.messages,
+      model: popupChatState.model,
+      sessionProjectId: popupChatState.sessionProjectId,
+      contextSummary: popupChatState.contextSummary,
+      updatedAt: Date.now()
+    }
+  });
+}
+
+async function loadPopupChatState() {
+  const data = await chrome.storage.local.get(['settings', CHAT_STORAGE_KEY, CHAT_PENDING_KEY]);
+  const settings = data.settings || {};
+  const saved = data[CHAT_STORAGE_KEY] || null;
+  const pending = data[CHAT_PENDING_KEY] || null;
+
+  popupChatState.model = settings.openRouterModel || saved?.model || 'openai/gpt-4o-mini';
+  document.getElementById('chatModel').textContent = popupChatState.model;
+
+  if (pending) {
+    const initialPrompt = String(pending.initialPrompt || '').trim();
+    resetChatForProject(pending.project || null, initialPrompt);
+
+    await chrome.storage.local.remove([CHAT_PENDING_KEY]);
+    document.getElementById('chatComposer').value = '';
+    renderProjectInfo();
+    renderChatMessages();
+
+    await persistPopupChatState();
+    if (popupChatState.messages.length > 0) {
+      await requestAssistantReply();
+    } else {
+      setChatStatus('تعذر تحميل prompt المشروع');
+    }
+    return;
+  }
+
+  popupChatState.project = saved?.project || null;
+  popupChatState.messages = Array.isArray(saved?.messages) ? saved.messages : [];
+  popupChatState.sessionProjectId = saved?.sessionProjectId || saved?.project?.id || '';
+  popupChatState.contextSummary = saved?.contextSummary || buildProjectContextSummary(saved?.project || null);
+
+  renderProjectInfo();
+  renderChatMessages();
+}
+
+// ==========================================
+// AI Chat Tab — Rendering
+// ==========================================
+
+function renderProjectInfo() {
+  const project = popupChatState.project;
+  if (!project) {
+    document.getElementById('chatProjectTitle').textContent = 'بانتظار مشروع...';
+    document.getElementById('chatProjectMeta').textContent = 'اضغط زر الذكاء من صفحة المشروع لبدء المحادثة هنا.';
+    return;
+  }
+
+  document.getElementById('chatProjectTitle').textContent = project.title || 'مشروع مستقل';
+  document.getElementById('chatProjectMeta').textContent =
+    [project.clientName, project.budget, project.duration].filter(Boolean).join(' - ');
+}
+
+function renderChatMessages() {
+  const container = document.getElementById('chatMessages');
+  const messages = popupChatState.messages || [];
+
+  if (messages.length === 0) {
+    container.innerHTML = '<div class="chat-empty">نفس الـ prompt الجاهز سيظهر هنا عند الضغط على زر الذكاء من صفحة المشروع.</div>';
+    return;
+  }
+
+  container.innerHTML = messages.map((msg, i) => {
+    const body = msg.pending
+      ? '<div class="typing"><span></span><span></span><span></span></div>'
+      : (msg.role === 'assistant' ? renderMarkdown(msg.content) : `<p>${escapeHtml(msg.content)}</p>`);
+
+    const actions = (msg.role === 'assistant' && !msg.pending)
+      ? '<div class="chat-actions"><button class="mini-btn" data-action="copy">نسخ</button><button class="mini-btn" data-action="apply">تعبئة</button></div>'
+      : '';
+
+    return `<article class="chat-message ${escapeHtml(msg.role)}" data-index="${i}">` +
+      `<div class="chat-bubble">` +
+        `<div class="chat-role">${msg.role === 'user' ? 'You' : 'AI'}</div>` +
+        `<div>${body}</div>${actions}` +
+      `</div></article>`;
+  }).join('');
+
+  container.querySelectorAll('.mini-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const idx = Number(btn.closest('.chat-message').dataset.index);
+      const msg = popupChatState.messages[idx];
+      if (!msg) return;
+      if (btn.dataset.action === 'copy') copyToClipboard(msg.content, btn);
+      if (btn.dataset.action === 'apply') applyProposalToProject(msg.content);
+    });
+  });
+
+  container.scrollTop = container.scrollHeight;
+}
+
+// ==========================================
+// AI Chat Tab — Messaging
+// ==========================================
+
+async function sendChatMessage() {
+  const composer = document.getElementById('chatComposer');
+  const text = composer.value.trim();
+  if (!text || popupChatState.loading) return;
+
+  popupChatState.messages.push({ role: 'user', content: text });
+  composer.value = '';
+  renderChatMessages();
+  await persistPopupChatState();
+  await requestAssistantReply();
+}
+
+async function requestAssistantReply() {
+  if (popupChatState.loading) return;
+  popupChatState.loading = true;
+  setChatStatus('جاري التوليد...');
+
+  popupChatState.messages.push({ role: 'assistant', content: '', pending: true });
+  renderChatMessages();
+
+  const outbound = prepareMessagesForApi(
+    popupChatState.messages,
+    popupChatState.contextSummary
+  );
+
+  chrome.runtime.sendMessage({
+    action: 'generateOpenRouterProposal',
+    messages: outbound
+  }, async (response) => {
+    popupChatState.loading = false;
+    popupChatState.messages = popupChatState.messages.filter((m) => !m.pending);
+
+    if (chrome.runtime.lastError || !response || !response.success) {
+      const errorMsg = chrome.runtime.lastError?.message
+        || response?.error
+        || 'خطأ غير معروف';
+      popupChatState.messages.push({ role: 'assistant', content: 'تعذر توليد الرد: ' + errorMsg });
+      setChatStatus('فشل التوليد');
+    } else {
+      popupChatState.model = response.model || popupChatState.model;
+      document.getElementById('chatModel').textContent = popupChatState.model;
+      popupChatState.messages.push({ role: 'assistant', content: response.text });
+      setChatStatus('جاهز');
+    }
+
+    renderChatMessages();
+    await persistPopupChatState();
+  });
+}
+
+async function clearChat() {
+  resetChatForProject(popupChatState.project, '');
+  document.getElementById('chatComposer').value = '';
+  setChatStatus('تم بدء محادثة جديدة');
+  renderProjectInfo();
+  renderChatMessages();
+  await persistPopupChatState();
+}
+
+// ==========================================
+// AI Chat Tab — Autofill Bridge
+// ==========================================
+
+function getRenderedPlainText(text) {
+  const temp = document.createElement('div');
+  temp.className = 'chat-bubble';
+  temp.style.cssText = 'position:fixed;left:-99999px;top:0;width:360px';
+  temp.innerHTML = renderMarkdown(text || '');
+  document.body.appendChild(temp);
+
+  const plain = (temp.innerText || temp.textContent || '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+  temp.remove();
+  return plain;
+}
+
+async function applyProposalToProject(proposalText) {
+  const projectId = popupChatState.project?.id || popupChatState.sessionProjectId || '';
+  const projectUrl = popupChatState.project?.url || '';
+
+  if (!projectId) {
+    setChatStatus('لا يوجد مشروع مرتبط');
+    return;
+  }
+
+  const cleanProposal = getRenderedPlainText(proposalText);
+  const payload = buildAutofillPayload(cleanProposal, popupChatState.project || {}, popupChatState.sessionProjectId);
+  await chrome.storage.local.set({ mostaql_pending_autofill: payload });
+  setChatStatus('تم تجهيز تعبئة العرض');
+
+  const tabs = await chrome.tabs.query({ url: 'https://mostaql.com/*' });
+  const target = tabs.find((tab) => tab.url && tab.url.includes(projectId));
+  if (target?.id) {
+    await chrome.tabs.update(target.id, { active: true });
+  } else if (projectUrl) {
+    await chrome.tabs.create({ url: projectUrl });
   }
 }

--- a/popup.js
+++ b/popup.js
@@ -235,7 +235,7 @@ async function loadPopupChatState() {
   const saved = data[CHAT_STORAGE_KEY] || null;
   const pending = data[CHAT_PENDING_KEY] || null;
 
-  popupChatState.model = settings.openRouterModel || saved?.model || 'openai/gpt-4o-mini';
+  popupChatState.model = settings.openRouterModel || saved?.model || 'openrouter/hunter-alpha';
   document.getElementById('chatModel').textContent = popupChatState.model;
 
   if (pending) {

--- a/popup.js
+++ b/popup.js
@@ -187,6 +187,11 @@ function setupChatListeners() {
     if (changes.popupActiveTab?.newValue === 'ai-chat') {
       activateTab('ai-chat');
     }
+
+    // Background updated the chat session (e.g. API response arrived)
+    if (changes[CHAT_STORAGE_KEY]?.newValue) {
+      await reloadChatFromStorage();
+    }
   });
 }
 
@@ -255,9 +260,52 @@ async function loadPopupChatState() {
   popupChatState.messages = Array.isArray(saved?.messages) ? saved.messages : [];
   popupChatState.sessionProjectId = saved?.sessionProjectId || saved?.project?.id || '';
   popupChatState.contextSummary = saved?.contextSummary || buildProjectContextSummary(saved?.project || null);
+  popupChatState.loading = popupChatState.messages.some((m) => m.pending);
+
+  if (popupChatState.loading) {
+    setChatStatus('جاري التوليد...');
+  }
 
   renderProjectInfo();
   renderChatMessages();
+}
+
+async function reloadChatFromStorage() {
+  const data = await chrome.storage.local.get(['settings', CHAT_STORAGE_KEY]);
+  const settings = data.settings || {};
+  const saved = data[CHAT_STORAGE_KEY] || null;
+
+  popupChatState.model = settings.openRouterModel || saved?.model || popupChatState.model;
+  document.getElementById('chatModel').textContent = popupChatState.model;
+
+  const prevMessages = popupChatState.messages;
+  const newMessages = Array.isArray(saved?.messages) ? saved.messages : [];
+
+  popupChatState.project = saved?.project || popupChatState.project;
+  popupChatState.messages = newMessages;
+  popupChatState.sessionProjectId = saved?.sessionProjectId || popupChatState.sessionProjectId;
+  popupChatState.contextSummary = saved?.contextSummary || popupChatState.contextSummary;
+
+  const wasLoading = popupChatState.loading;
+  popupChatState.loading = newMessages.some((m) => m.pending);
+
+  setChatStatus(popupChatState.loading ? 'جاري التوليد...' : 'جاهز');
+
+  // Detect streaming update: same message count, last message is pending
+  // with content changing — use lightweight bubble update instead of full rebuild
+  const isStreamingUpdate =
+    popupChatState.loading &&
+    newMessages.length === prevMessages.length &&
+    newMessages.length > 0 &&
+    newMessages[newMessages.length - 1].pending &&
+    newMessages[newMessages.length - 1].content;
+
+  if (isStreamingUpdate) {
+    updateStreamingBubble();
+  } else {
+    renderProjectInfo();
+    renderChatMessages();
+  }
 }
 
 // ==========================================
@@ -287,9 +335,16 @@ function renderChatMessages() {
   }
 
   container.innerHTML = messages.map((msg, i) => {
-    const body = msg.pending
-      ? '<div class="typing"><span></span><span></span><span></span></div>'
-      : (msg.role === 'assistant' ? renderMarkdown(msg.content) : `<p>${escapeHtml(msg.content)}</p>`);
+    let body;
+    if (msg.pending && !msg.content) {
+      body = '<div class="typing"><span></span><span></span><span></span></div>';
+    } else if (msg.pending && msg.content) {
+      body = renderMarkdown(msg.content) + '<div class="typing"><span></span><span></span><span></span></div>';
+    } else if (msg.role === 'assistant') {
+      body = renderMarkdown(msg.content);
+    } else {
+      body = `<p>${escapeHtml(msg.content)}</p>`;
+    }
 
     const actions = (msg.role === 'assistant' && !msg.pending)
       ? '<div class="chat-actions"><button class="mini-btn" data-action="copy">نسخ</button><button class="mini-btn" data-action="apply">تعبئة</button></div>'
@@ -298,7 +353,7 @@ function renderChatMessages() {
     return `<article class="chat-message ${escapeHtml(msg.role)}" data-index="${i}">` +
       `<div class="chat-bubble">` +
         `<div class="chat-role">${msg.role === 'user' ? 'You' : 'AI'}</div>` +
-        `<div>${body}</div>${actions}` +
+        `<div class="chat-body">${body}</div>${actions}` +
       `</div></article>`;
   }).join('');
 
@@ -311,6 +366,34 @@ function renderChatMessages() {
       if (btn.dataset.action === 'apply') applyProposalToProject(msg.content);
     });
   });
+
+  container.scrollTop = container.scrollHeight;
+}
+
+/**
+ * Lightweight update for streaming: only re-renders the last pending message
+ * bubble instead of rebuilding the entire message list.
+ */
+function updateStreamingBubble() {
+  const container = document.getElementById('chatMessages');
+  const messages = popupChatState.messages || [];
+  const lastMsg = messages[messages.length - 1];
+
+  if (!lastMsg || !lastMsg.pending) return;
+
+  const lastArticle = container.querySelector(`[data-index="${messages.length - 1}"]`);
+  if (!lastArticle) {
+    renderChatMessages();
+    return;
+  }
+
+  const bodyEl = lastArticle.querySelector('.chat-body');
+  if (!bodyEl) return;
+
+  if (lastMsg.content) {
+    bodyEl.innerHTML = renderMarkdown(lastMsg.content) +
+      '<div class="typing"><span></span><span></span><span></span></div>';
+  }
 
   container.scrollTop = container.scrollHeight;
 }
@@ -338,6 +421,7 @@ async function requestAssistantReply() {
 
   popupChatState.messages.push({ role: 'assistant', content: '', pending: true });
   renderChatMessages();
+  await persistPopupChatState();
 
   const outbound = prepareMessagesForApi(
     popupChatState.messages,
@@ -347,25 +431,11 @@ async function requestAssistantReply() {
   chrome.runtime.sendMessage({
     action: 'generateOpenRouterProposal',
     messages: outbound
-  }, async (response) => {
-    popupChatState.loading = false;
-    popupChatState.messages = popupChatState.messages.filter((m) => !m.pending);
-
-    if (chrome.runtime.lastError || !response || !response.success) {
-      const errorMsg = chrome.runtime.lastError?.message
-        || response?.error
-        || 'خطأ غير معروف';
-      popupChatState.messages.push({ role: 'assistant', content: 'تعذر توليد الرد: ' + errorMsg });
-      setChatStatus('فشل التوليد');
-    } else {
-      popupChatState.model = response.model || popupChatState.model;
-      document.getElementById('chatModel').textContent = popupChatState.model;
-      popupChatState.messages.push({ role: 'assistant', content: response.text });
-      setChatStatus('جاهز');
-    }
-
-    renderChatMessages();
-    await persistPopupChatState();
+  }, () => {
+    // Background has already written the result to storage.
+    // The storage.onChanged listener will call reloadChatFromStorage().
+    // This callback is only needed to suppress chrome.runtime.lastError.
+    void chrome.runtime.lastError;
   });
 }
 

--- a/shared/chat-utils.js
+++ b/shared/chat-utils.js
@@ -1,0 +1,85 @@
+// ==========================================
+// shared/chat-utils.js — Reusable chat helper functions
+// Shared between popup chat and any future chat surfaces
+// ==========================================
+
+const CHAT_STORAGE_KEY = 'openRouterChatSession';
+const CHAT_PENDING_KEY = 'openRouterPendingChat';
+
+/**
+ * Copy text to clipboard and optionally flash a button label.
+ */
+async function copyToClipboard(text, button) {
+  try {
+    await navigator.clipboard.writeText(text);
+    if (button) {
+      const original = button.textContent;
+      button.textContent = 'تم';
+      setTimeout(() => { button.textContent = original; }, 1000);
+    }
+  } catch (_) {
+    // silently fail — caller can handle via status
+  }
+}
+
+/**
+ * Build autofill payload from a proposal and project metadata.
+ */
+function buildAutofillPayload(proposalText, project, sessionProjectId) {
+  const durationMatch = String(project.duration || '').match(/\d+/);
+  const budgetMatch = String(project.budget || '').replace(/,/g, '').match(/\d+(\.\d+)?/);
+
+  return {
+    projectId: project.id || sessionProjectId || '',
+    amount: budgetMatch ? parseFloat(budgetMatch[0]) : 0,
+    duration: durationMatch ? parseInt(durationMatch[0], 10) : 0,
+    proposal: proposalText,
+    timestamp: Date.now()
+  };
+}
+
+/**
+ * Build a project context summary for the AI system prompt.
+ */
+function buildProjectContextSummary(project) {
+  if (!project) return '';
+
+  return [
+    'هذه المحادثة مرتبطة بمشروع مستقل محدد. استخدم هذا السياق في كل رد.',
+    `عنوان المشروع: ${project.title || 'غير معروف'}`,
+    `رابط المشروع: ${project.url || 'غير معروف'}`,
+    `الميزانية: ${project.budget || 'غير معروف'}`,
+    `مدة التنفيذ: ${project.duration || 'غير معروف'}`,
+    `صاحب العمل: ${project.clientName || 'غير معروف'}`,
+    `معرف المشروع: ${project.id || 'غير معروف'}`,
+    'إذا طُلب منك كتابة عرض، فاكتب عرضاً جاهزاً للإرسال وبالعربية ما لم يطلب المستخدم غير ذلك.'
+  ].join('\n');
+}
+
+/**
+ * Prepare messages for the OpenRouter API:
+ * - Filter invalid/pending messages
+ * - Strip error messages
+ * - Keep last N messages
+ * - Prepend project context to first user message
+ */
+function prepareMessagesForApi(messages, contextSummary, maxMessages) {
+  const limit = maxMessages || 8;
+  const cleaned = messages
+    .filter((m) => m && !m.pending && (m.role === 'user' || m.role === 'assistant'))
+    .map((m) => ({ role: m.role, content: String(m.content || '').trim() }))
+    .filter((m) => m.content)
+    .filter((m) => !(m.role === 'assistant' && m.content.startsWith('تعذر توليد الرد:')))
+    .slice(-limit);
+
+  if (cleaned.length === 0) return cleaned;
+
+  if (contextSummary && cleaned[0].role === 'user') {
+    cleaned[0] = {
+      role: 'user',
+      content: `${contextSummary}\n\nطلب المستخدم:\n${cleaned[0].content}`
+    };
+  }
+
+  return cleaned;
+}

--- a/shared/markdown.js
+++ b/shared/markdown.js
@@ -1,0 +1,115 @@
+// ==========================================
+// shared/markdown.js — Lightweight Markdown renderer
+// Shared between popup and any future chat surfaces
+// ==========================================
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderInlineMarkdown(text) {
+  return text
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '<a href="$2" target="_blank" rel="noreferrer noopener">$1</a>')
+    .replace(/`([^`]+)`/g, '<code>$1</code>')
+    .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*([^*]+)\*/g, '<em>$1</em>');
+}
+
+function renderMarkdown(text) {
+  const safe = escapeHtml(text || '');
+  const lines = safe.split('\n');
+  const parts = [];
+  let inList = false;
+  let inOrderedList = false;
+  let inCodeBlock = false;
+  let codeLines = [];
+  let tableRows = [];
+
+  const closeList = () => {
+    if (inList) { parts.push('</ul>'); inList = false; }
+    if (inOrderedList) { parts.push('</ol>'); inOrderedList = false; }
+  };
+
+  const flushCodeBlock = () => {
+    if (inCodeBlock) {
+      parts.push(`<pre><code>${codeLines.join('\n')}</code></pre>`);
+      inCodeBlock = false;
+      codeLines = [];
+    }
+  };
+
+  const isTableSeparator = (line) =>
+    /^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?$/.test(line);
+
+  const flushTable = () => {
+    if (tableRows.length < 2 || !isTableSeparator(tableRows[1])) {
+      for (const row of tableRows) {
+        parts.push(`<p>${renderInlineMarkdown(row)}</p>`);
+      }
+      tableRows = [];
+      return;
+    }
+
+    const splitRow = (row) =>
+      row.replace(/^\|/, '').replace(/\|$/, '').split('|').map((cell) => renderInlineMarkdown(cell.trim()));
+
+    const headers = splitRow(tableRows[0]);
+    const bodyRows = tableRows.slice(2).map(splitRow);
+
+    parts.push('<div class="table-wrap"><table><thead><tr>' + headers.map((c) => `<th>${c}</th>`).join('') + '</tr></thead><tbody>');
+    for (const row of bodyRows) {
+      parts.push('<tr>' + row.map((c) => `<td>${c}</td>`).join('') + '</tr>');
+    }
+    parts.push('</tbody></table></div>');
+    tableRows = [];
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (/^```/.test(trimmed)) {
+      closeList();
+      flushTable();
+      if (inCodeBlock) { flushCodeBlock(); } else { inCodeBlock = true; codeLines = []; }
+      continue;
+    }
+
+    if (inCodeBlock) { codeLines.push(line); continue; }
+    if (!trimmed) { closeList(); flushTable(); continue; }
+
+    if (/^\|.+\|$/.test(trimmed)) { closeList(); tableRows.push(trimmed); continue; }
+    flushTable();
+
+    if (/^###\s+/.test(trimmed)) { closeList(); parts.push(`<h3>${renderInlineMarkdown(trimmed.replace(/^###\s+/, ''))}</h3>`); continue; }
+    if (/^##\s+/.test(trimmed))  { closeList(); parts.push(`<h2>${renderInlineMarkdown(trimmed.replace(/^##\s+/, ''))}</h2>`); continue; }
+    if (/^#\s+/.test(trimmed))   { closeList(); parts.push(`<h1>${renderInlineMarkdown(trimmed.replace(/^#\s+/, ''))}</h1>`); continue; }
+
+    if (/^-\s+/.test(trimmed)) {
+      if (!inList) { if (inOrderedList) { parts.push('</ol>'); inOrderedList = false; } parts.push('<ul>'); inList = true; }
+      parts.push(`<li>${renderInlineMarkdown(trimmed.replace(/^-\s+/, ''))}</li>`);
+      continue;
+    }
+
+    if (/^\d+\.\s+/.test(trimmed)) {
+      if (!inOrderedList) { if (inList) { parts.push('</ul>'); inList = false; } parts.push('<ol>'); inOrderedList = true; }
+      parts.push(`<li>${renderInlineMarkdown(trimmed.replace(/^\d+\.\s+/, ''))}</li>`);
+      continue;
+    }
+
+    if (/^>\s+/.test(trimmed)) { closeList(); parts.push(`<blockquote>${renderInlineMarkdown(trimmed.replace(/^>\s+/, ''))}</blockquote>`); continue; }
+    if (/^---+$/.test(trimmed)) { closeList(); parts.push('<hr>'); continue; }
+
+    closeList();
+    parts.push(`<p>${renderInlineMarkdown(trimmed)}</p>`);
+  }
+
+  closeList();
+  flushTable();
+  flushCodeBlock();
+  return parts.join('');
+}


### PR DESCRIPTION
## Summary
Adds a full AI chat feature to the Frelancia Chrome extension, powered by OpenRouter. Users can interact with an AI assistant directly from the popup, with project context automatically injected from Mostaql project pages.
## What's included
### Core API Integration
- **OpenRouter API module** (`bg/openrouter.js`) — supports both streaming (SSE) and non-streaming requests, with automatic fallback if the provider rejects streaming
- **Message handler** (`bg/message-handler.js`) — routes `generateOpenRouterProposal` actions through the background service worker with throttled storage writes during streaming (every 300ms)
- **Shared utilities** (`shared/markdown.js`, `shared/chat-utils.js`) — reusable markdown renderer and chat helpers (message preparation, autofill payload building, project context summarization)
### Popup Chat UI
- **New AI Chat tab** in the popup with a composer, message list, typing indicator, and streaming text display
- **Per-message actions**: copy to clipboard, autofill proposal into Mostaql project page
- **Project context awareness**: when triggered from a project page, the chat session carries the project title, budget, duration, and client info as system context
- **Lightweight streaming updates**: `updateStreamingBubble()` only re-renders the last pending message bubble instead of rebuilding the entire DOM during streaming
### Popup-Close Resilience
- Background writes chat state directly to `chrome.storage.local` — the popup is purely reactive via `storage.onChanged`
- If the popup closes mid-generation, the background completes independently; reopening the popup recovers the correct state (in-progress or finished)
- Three scenarios handled: popup stays open, popup reopened after completion, popup reopened mid-stream
### Dashboard Settings
- **AI Provider selection** (ChatGPT redirect vs OpenRouter API) in the dashboard settings page
- **Model configuration** with a text input and preset dropdown for common free models
- **API key management** with masked input field
- Default model changed to `openrouter/hunter-alpha` (free, reliable)
### Provider Routing
- `content/project-sidebar.js` routes AI actions through the selected provider — ChatGPT opens a new tab with the prompt, OpenRouter sends to the background handler and opens the popup chat
- `content/autofill.js` watches for autofill payloads in storage and fills Mostaql proposal forms reactively
### Permissions
- Added `tabs` permission (needed for `chrome.tabs.query` to find Mostaql tabs for autofill)
- Added `https://openrouter.ai/*` host permission for API calls
## Commits (10)
| Commit | Description |
|--------|-------------|
| `772bb7d` | feat: add OpenRouter API integration module |
| `7d1ce7a` | feat: add AI provider settings to dashboard |
| `9f9ff86` | feat: add AI provider defaults and settings migration |
| `4557383` | feat: add message handlers for OpenRouter and popup |
| `b7e78c6` | feat: route AI actions through provider selection |
| `d2b5ce3` | feat: add AI chat tab to popup with shared modules |
| `10d9fc7` | chore: add tabs permission and OpenRouter host permission |
| `820528e` | feat: add streaming responses with popup-resilient state management |
| `45e581c` | fix: fall back to non-streaming when provider rejects stream requests |
| `b9812d1` | fix: change default model to openrouter/hunter-alpha and improve error guidance |
## Files changed
16 files changed, **1,639 additions**, 175 deletions
## Testing
1. Install/reload the extension
2. Go to Dashboard → Settings → set AI Provider to "OpenRouter" and paste an API key
3. Open any Mostaql project page → click the AI button in the sidebar
4. The popup opens with the AI Chat tab, project context loaded, and the AI starts generating
5. Test popup close during generation → reopen → verify state recovery
6. Test "تعبئة" (autofill) button → verify proposal fills into the Mostaql form
---
<img width="1047" height="260" alt="Screenshot 2026-03-17 082353" src="https://github.com/user-attachments/assets/b65b7a60-4c46-4d7b-9357-cffd6989d3bb" />
<img width="327" height="540" alt="Screenshot 2026-03-17 082418" src="https://github.com/user-attachments/assets/d16fa067-9548-457d-8bdc-97f967649818" />