### PR TITLE
feat: add sidebar/popup display mode toggle

### DIFF
--- a/background.js
+++ b/background.js
@@ -38,13 +38,38 @@ importScripts(
   'bg/message-handler.js'  // onMessage handler
 );
 
+// ==========================================
+// Display Mode: Popup vs Sidebar
+// ==========================================
+
+async function applyDisplayMode(mode) {
+  if (mode === 'sidebar') {
+    // Disable popup so clicking the icon opens the side panel
+    await chrome.action.setPopup({ popup: '' });
+    await chrome.sidePanel.setOptions({ path: 'popup.html', enabled: true });
+    await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+    console.log('Display mode: sidebar');
+  } else {
+    // Disable side panel entirely, re-enable popup
+    await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+    await chrome.sidePanel.setOptions({ enabled: false });
+    await chrome.action.setPopup({ popup: 'popup.html' });
+    console.log('Display mode: popup');
+  }
+}
+
 // Service worker startup
 (async function initOnStartup() {
   console.log('Service worker started');
   const data = await chrome.storage.local.get(['settings']);
-  const mode = (data.settings || {}).notificationMode || 'auto';
+  const settings = data.settings || {};
+  const notifMode = settings.notificationMode || 'auto';
 
-  if (mode === 'polling') {
+  // Apply display mode (sidebar by default)
+  const displayMode = settings.displayMode || 'sidebar';
+  await applyDisplayMode(displayMode);
+
+  if (notifMode === 'polling') {
     console.log('📡 Notification mode: polling — skipping SignalR init');
     return;
   }

--- a/bg/message-handler.js
+++ b/bg/message-handler.js
@@ -5,6 +5,26 @@
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
+  if (message.action === 'setDisplayMode') {
+    const mode = message.mode === 'sidebar' ? 'sidebar' : 'popup';
+    const tabId = message.tabId || null;
+
+    applyDisplayMode(mode)
+      .then(async () => {
+        if (mode === 'sidebar' && tabId) {
+          // Open the side panel immediately on the requesting tab
+          try {
+            await chrome.sidePanel.open({ tabId });
+          } catch (e) {
+            console.warn('Could not auto-open side panel:', e.message);
+          }
+        }
+        sendResponse({ success: true, mode });
+      })
+      .catch((e) => sendResponse({ success: false, error: e.message }));
+    return true;
+  }
+
   if (message.action === 'checkNow') {
     checkForNewJobs()
       .then((result) => sendResponse(result))

--- a/dashboard.css
+++ b/dashboard.css
@@ -887,3 +887,69 @@ input:checked+.slider:before {
     color: var(--text-body);
     line-height: 1.8;
 }
+
+/* Display Mode Switcher */
+.display-mode-switcher {
+    display: flex;
+    gap: 16px;
+    margin-top: 8px;
+}
+
+.mode-option {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    padding: 24px 16px;
+    border-radius: var(--radius-md);
+    border: 2px solid var(--border);
+    background: #f8fafc;
+    cursor: pointer;
+    transition: var(--transition);
+    font-family: inherit;
+}
+
+.mode-option i {
+    font-size: 28px;
+    color: var(--text-muted);
+    transition: var(--transition);
+}
+
+.mode-option .mode-label {
+    font-size: 15px;
+    font-weight: 800;
+    color: var(--text-title);
+}
+
+.mode-option .mode-desc {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.mode-option:hover {
+    border-color: var(--primary);
+    background: white;
+}
+
+.mode-option:hover i {
+    color: var(--primary);
+}
+
+.mode-option.active {
+    border-color: var(--primary);
+    background: var(--primary-soft);
+    box-shadow: 0 0 0 4px rgba(0, 97, 255, 0.08);
+}
+
+.mode-option.active i {
+    color: var(--primary);
+}
+
+.mode-option.active .mode-desc {
+    color: var(--primary);
+    font-weight: 800;
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -331,6 +331,32 @@
                 <div class="settings-grid">
                     <div class="settings-section">
                         <div class="section-header">
+                            <i class="fas fa-window-maximize"></i>
+                            <h3>وضع العرض</h3>
+                        </div>
+                        <div class="form-group">
+                            <label>نمط واجهة الإضافة</label>
+                            <div class="display-mode-switcher">
+                                <button type="button" class="mode-option" data-mode="popup" id="modePopup">
+                                    <i class="fas fa-window-restore"></i>
+                                    <span class="mode-label">نافذة منبثقة</span>
+                                    <span class="mode-desc">Popup</span>
+                                </button>
+                                <button type="button" class="mode-option active" data-mode="sidebar" id="modeSidebar">
+                                    <i class="fas fa-columns"></i>
+                                    <span class="mode-label">شريط جانبي</span>
+                                    <span class="mode-desc">Sidebar</span>
+                                </button>
+                            </div>
+                            <p class="help-text">
+                                <strong>نافذة منبثقة:</strong> تظهر كنافذة صغيرة عند الضغط على أيقونة الإضافة.<br>
+                                <strong>شريط جانبي:</strong> تظهر كلوحة جانبية ثابتة بجوار الصفحة الحالية.
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="settings-section">
+                        <div class="section-header">
                             <i class="fas fa-robot"></i>
                             <h3>رابط الذكاء الاصطناعي</h3>
                         </div>

--- a/dashboard/events.js
+++ b/dashboard/events.js
@@ -63,6 +63,38 @@ function setupEventListeners() {
         });
     }
 
+    // Display mode switcher (popup / sidebar) — applies instantly on click
+    document.querySelectorAll('.mode-option').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const newMode = btn.dataset.mode;
+            const currentActive = document.querySelector('.mode-option.active');
+            if (currentActive && currentActive.dataset.mode === newMode) return; // already active
+
+            // Update UI
+            document.querySelectorAll('.mode-option').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+
+            // Save immediately to storage
+            chrome.storage.local.get(['settings'], (data) => {
+                const s = data.settings || {};
+                s.displayMode = newMode;
+                chrome.storage.local.set({ settings: s }, () => {
+                    showSaveStatus();
+
+                    // Get the current active tab to open sidebar on it
+                    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+                        const tabId = tabs[0]?.id || null;
+                        chrome.runtime.sendMessage({
+                            action: 'setDisplayMode',
+                            mode: newMode,
+                            tabId: tabId
+                        });
+                    });
+                });
+            });
+        });
+    });
+
     // System toggle — auto-save immediately on change
     const systemToggle = document.getElementById('systemToggle');
     if (systemToggle) {

--- a/dashboard/settings.js
+++ b/dashboard/settings.js
@@ -24,7 +24,8 @@ function saveAllSettings() {
         interval:         parseInt(getVal('checkInterval'))  || 1,
         systemEnabled:    getVal('systemToggle'),
         notificationMode: getVal('notificationMode') || 'auto',
-        signalrServerUrl: getVal('signalrServerUrl') || ''
+        signalrServerUrl: getVal('signalrServerUrl') || '',
+        displayMode:      document.querySelector('.mode-option.active')?.dataset.mode || 'sidebar'
     };
 
     const proposalTemplate = document.getElementById('proposalTemplate').value;
@@ -32,6 +33,7 @@ function saveAllSettings() {
     chrome.storage.local.set({ settings, proposalTemplate }, () => {
         showSaveStatus();
         chrome.runtime.sendMessage({ action: 'updateAlarm', interval: settings.interval });
+        // displayMode is applied instantly on button click — no need to re-send here
         if (settings.notificationMode === 'polling') {
             chrome.runtime.sendMessage({ action: 'disconnectSignalR' });
         } else {
@@ -71,4 +73,10 @@ function applySettingsToForm(s) {
     setVal('systemToggle',      s.systemEnabled !== false);
     setVal('notificationMode',  s.notificationMode || 'auto');
     setVal('signalrServerUrl',  s.signalrServerUrl || '');
+
+    // Display mode switcher
+    const displayMode = s.displayMode || 'sidebar';
+    document.querySelectorAll('.mode-option').forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.mode === displayMode);
+    });
 }

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     "alarms",
     "storage",
     "offscreen",
-    "downloads"
+    "downloads",
+    "sidePanel"
   ],
   "host_permissions": [
     "https://mostaql.com/*",
@@ -61,5 +62,8 @@
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
+  },
+  "side_panel": {
+    "default_path": "popup.html"
   }
 }

--- a/popup.css
+++ b/popup.css
@@ -177,6 +177,7 @@ body {
 .btn.primary:hover {
   transform: translateY(-1px);
   box-shadow: 0 6px 16px rgba(35, 134, 200, 0.35);
+  filter: brightness(0.9);
 }
 
 .btn.secondary {
@@ -263,7 +264,7 @@ body.popup-mode {
   width: 340px;
   min-height: 420px;
   height: auto;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 body.popup-mode .minimal-container {

--- a/popup.css
+++ b/popup.css
@@ -3,6 +3,7 @@
 :root {
   --primary: #2386c8;
   --primary-hover: #1e70a9;
+  --primary-gradient: linear-gradient(135deg, #2386c8 0%, #1ba8e0 100%);
   --bg: #f6f7f9;
   --card: #ffffff;
   --text-main: #3e4751;
@@ -20,27 +21,35 @@
   box-sizing: border-box;
 }
 
+/* ============================================
+   BASE: Sidebar mode (default)
+   ============================================ */
 body {
   font-family: 'Cairo', sans-serif;
   background-color: var(--bg);
   color: var(--text-main);
-  width: 340px;
-  min-height: 420px;
-  overflow: hidden;
+  width: 100%;
+  height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .minimal-container {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 100vh;
 }
 
+/* Header */
 .header {
-  background: var(--primary);
-  padding: 24px 16px;
+  background: var(--primary-gradient);
+  padding: 28px 20px;
   text-align: center;
   color: white;
   border-bottom: 2px solid rgba(0, 0, 0, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .main-logo {
@@ -48,7 +57,6 @@ body {
   height: 60px;
   margin-bottom: 12px;
   filter: brightness(0) invert(1);
-  /* Make logo white for blue background if needed */
 }
 
 .header h1 {
@@ -63,16 +71,19 @@ body {
   font-weight: 600;
 }
 
+/* Content */
 .content-body {
-  padding: 20px;
+  padding: 24px 20px;
+  flex: 1;
 }
 
+/* Stats */
 .stats-overview {
   display: flex;
   background: var(--card);
   border-radius: var(--radius);
-  padding: 16px;
-  margin-bottom: 20px;
+  padding: 20px 16px;
+  margin-bottom: 24px;
   border: 1px solid var(--border);
   box-shadow: var(--shadow);
 }
@@ -84,15 +95,17 @@ body {
 
 .stat-num {
   display: block;
-  font-size: 22px;
+  font-size: 26px;
   font-weight: 800;
   color: var(--primary);
+  line-height: 1.2;
 }
 
 .stat-label {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--text-sub);
   font-weight: 700;
+  margin-top: 4px;
 }
 
 .stat-divider {
@@ -101,29 +114,38 @@ body {
   margin: 0 12px;
 }
 
+/* Status indicator */
 .status-indicator {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 8px;
-  margin-bottom: 24px;
-  font-size: 12px;
+  margin-bottom: 28px;
+  font-size: 13px;
   font-weight: 700;
   color: var(--text-sub);
 }
 
 .dot {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
   border-radius: 50%;
   background: #cbd5e1;
+  flex-shrink: 0;
 }
 
 .dot.active {
   background: var(--success);
   box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.15);
+  animation: pulse 2s infinite;
 }
 
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.15); }
+  50% { box-shadow: 0 0 0 8px rgba(16, 185, 129, 0.08); }
+}
+
+/* Action buttons */
 .main-actions {
   display: flex;
   flex-direction: column;
@@ -132,8 +154,8 @@ body {
 
 .btn {
   width: 100%;
-  padding: 12px;
-  border-radius: 8px;
+  padding: 14px;
+  border-radius: 10px;
   border: none;
   font-family: inherit;
   font-size: 14px;
@@ -147,13 +169,14 @@ body {
 }
 
 .btn.primary {
-  background: var(--primary);
+  background: var(--primary-gradient);
   color: white;
+  box-shadow: 0 4px 12px rgba(35, 134, 200, 0.25);
 }
 
 .btn.primary:hover {
-  background: var(--primary-hover);
   transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(35, 134, 200, 0.35);
 }
 
 .btn.secondary {
@@ -171,7 +194,7 @@ body {
 .btn.toggle-off {
   background: #fdf2f2;
   color: var(--danger);
-  border-color: #fbc6c6;
+  border: 1px solid #fbc6c6;
 }
 
 .btn.toggle-off:hover {
@@ -182,7 +205,7 @@ body {
 
 /* Connection specific */
 .btn.connection {
-  padding: 6px;
+  padding: 8px;
   font-size: 11px;
   color: var(--text-sub);
   background: transparent;
@@ -196,11 +219,12 @@ body {
 }
 
 .connection-report {
-  font-size: 11px;
-  padding: 10px;
-  border-radius: 8px;
-  margin-top: 8px;
+  font-size: 12px;
+  padding: 12px;
+  border-radius: 10px;
+  margin-top: 12px;
   text-align: center;
+  font-weight: 600;
 }
 
 .connection-report.success {
@@ -213,10 +237,11 @@ body {
   color: #c62828;
 }
 
+/* Footer */
 .footer {
   margin-top: auto;
   text-align: center;
-  padding: 16px;
+  padding: 20px;
   border-top: 1px solid var(--border);
 }
 
@@ -225,4 +250,83 @@ body {
   color: var(--primary);
   text-decoration: none;
   font-weight: 700;
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* ============================================
+   POPUP MODE: Fixed small window
+   ============================================ */
+body.popup-mode {
+  width: 340px;
+  min-height: 420px;
+  height: auto;
+  overflow: hidden;
+}
+
+body.popup-mode .minimal-container {
+  min-height: auto;
+  height: 100%;
+}
+
+body.popup-mode .header {
+  position: static;
+  padding: 22px 16px;
+}
+
+body.popup-mode .content-body {
+  padding: 20px;
+}
+
+body.popup-mode .stats-overview {
+  padding: 16px;
+  margin-bottom: 20px;
+}
+
+body.popup-mode .stat-num {
+  font-size: 22px;
+}
+
+body.popup-mode .stat-label {
+  font-size: 11px;
+}
+
+body.popup-mode .status-indicator {
+  margin-bottom: 24px;
+  font-size: 12px;
+}
+
+body.popup-mode .dot {
+  width: 8px;
+  height: 8px;
+}
+
+body.popup-mode .btn {
+  padding: 12px;
+}
+
+body.popup-mode .footer {
+  padding: 16px;
+}
+
+/* ============================================
+   Scrollbar (sidebar only)
+   ============================================ */
+body:not(.popup-mode)::-webkit-scrollbar {
+  width: 6px;
+}
+
+body:not(.popup-mode)::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+body:not(.popup-mode)::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 10px;
+}
+
+body:not(.popup-mode)::-webkit-scrollbar-thumb:hover {
+  background: #94a3b8;
 }

--- a/popup.js
+++ b/popup.js
@@ -3,11 +3,20 @@
 // ==========================================
 
 document.addEventListener('DOMContentLoaded', () => {
+  // Detect display mode and apply the correct body class
+  chrome.storage.local.get(['settings'], (data) => {
+    const mode = (data.settings || {}).displayMode || 'sidebar';
+    if (mode === 'popup') {
+      document.body.classList.add('popup-mode');
+    }
+    // sidebar is the default — no class needed (base CSS handles it)
+  });
+
   // Initialize minimal UI
   loadStats();
   setupEventListeners();
   
-  // Refresh stats every 30 seconds while popup is open
+  // Refresh stats every 30 seconds while open
   setInterval(loadStats, 30000);
 });
 

--- a/popup.js
+++ b/popup.js
@@ -10,14 +10,14 @@ document.addEventListener('DOMContentLoaded', () => {
       document.body.classList.add('popup-mode');
     }
     // sidebar is the default — no class needed (base CSS handles it)
-  });
 
-  // Initialize minimal UI
-  loadStats();
-  setupEventListeners();
-  
-  // Refresh stats every 30 seconds while open
-  setInterval(loadStats, 30000);
+    // Initialize minimal UI only after the correct display mode class is applied
+    loadStats();
+    setupEventListeners();
+
+    // Refresh stats every 30 seconds while open
+    setInterval(loadStats, 30000);
+  });
 });
 
 // ==========================================


### PR DESCRIPTION
## Summary
- Add a display mode toggle that lets users switch between **Chrome Side Panel (sidebar)** and **traditional popup** modes from the Advanced Settings tab in the dashboard
- **Sidebar is the default mode** — clicking the extension icon opens the Side Panel instead of a small popup
- Mode switches apply **instantly on click** without needing to save settings or restart the extension
## Changes
### Manifest & Permissions
- Added `sidePanel` permission and `side_panel.default_path` config pointing to `popup.html`
### Background Script
- Added `applyDisplayMode(mode)` function that toggles between sidebar and popup by enabling/disabling the Side Panel API and swapping the action popup
- On startup, reads stored `displayMode` (defaults to `sidebar`) and applies it
### Message Handler
- Added `setDisplayMode` message handler that calls `applyDisplayMode()` and auto-opens the side panel via `chrome.sidePanel.open({ tabId })` when switching to sidebar mode
### Dashboard UI
- Added "وضع العرض" (Display Mode) section at the top of the Advanced Settings tab with two styled card buttons (popup / sidebar)
- Mode buttons apply instantly on click: update UI, save to storage, query active tab, send message to background
- Added `.display-mode-switcher` and `.mode-option` component styles matching the existing premium design
### Popup (dual-mode support)
- Rewrote `popup.css` — base styles are sidebar mode (full width, 100vh, sticky header, scrollbar), `body.popup-mode` class applies old 340px fixed popup styles
- `popup.js` detects `displayMode` on load and adds `popup-mode` class to body if in popup mode
## Files Changed (9 files, +327 / -33)
- `manifest.json` — sidePanel permission + config
- `background.js` — applyDisplayMode() + startup init
- `bg/message-handler.js` — setDisplayMode handler
- `dashboard.html` — display mode switcher UI
- `dashboard.css` — switcher component styles
- `dashboard/events.js` — instant mode switch on click
- `dashboard/settings.js` — displayMode in save/load
- `popup.css` — dual-mode CSS (sidebar base + popup-mode class)
- `popup.js` — mode detection + class application
## Known Limitation
When switching from sidebar → popup, Chrome provides no API to programmatically close an already-open side panel. The user must close it manually.