### PR TITLE
feat: add clipboard image paste auto-upload support

### DIFF
--- a/content/clipboard-main.js
+++ b/content/clipboard-main.js
@@ -1,0 +1,97 @@
+// ==========================================
+// content/clipboard-main.js — Handles pasting clipboard images directly into chat
+// Loaded as a web accessible resource inside the page's MAIN world to bypass CSP and isolated worlds.
+// ==========================================
+
+(function() {
+    function initMainWorldClipboard() {
+        const chatInput = document.querySelector('.editor__input');
+        if (!chatInput) return;
+
+        // Ensure no duplicate event listeners in the main world
+        if (chatInput.dataset.clipboardPasteHookedMain === 'true') return;
+        chatInput.dataset.clipboardPasteHookedMain = 'true';
+
+        chatInput.addEventListener('paste', function(event) {
+            console.log('[DEBUG] Mostaql Notifier: Paste event detected inside chatInput!');
+
+            // Dynamically query fileInput on each paste to prevent stale/detached references
+            const fileInput = document.querySelector('.chat-form__multimedia input[type="file"]');
+            if (!fileInput) {
+                console.log('[DEBUG] Mostaql Notifier: Upload file input not found in the DOM!');
+                return;
+            }
+
+            const items = (event.clipboardData || event.originalEvent?.clipboardData)?.items;
+            if (!items) {
+                console.log('[DEBUG] Mostaql Notifier: No clipboard items found.');
+                return;
+            }
+
+            console.log('[DEBUG] Mostaql Notifier: Clipboard items count:', items.length);
+
+            let imagePasted = false;
+            for (let i = 0; i < items.length; i++) {
+                console.log(`[DEBUG] Mostaql Notifier: Item ${i} type:`, items[i].type);
+                if (items[i].type.indexOf('image') !== -1) {
+                    const blob = items[i].getAsFile();
+                    if (!blob) {
+                        console.log(`[DEBUG] Mostaql Notifier: Item ${i} could not be extracted as File/Blob.`);
+                        continue;
+                    }
+                    let extension = "png";
+                    if (blob.type) {
+                        const parts = blob.type.split('/');
+                        if (parts.length > 1) {
+                            extension = parts[1].split('+')[0];
+                        }
+                    }
+                    const filename = `pasted_image_${Date.now()}_${Math.floor(Math.random() * 100000)}.${extension}`;
+                    console.log(`[DEBUG] Mostaql Notifier: Generating unique filename for upload:`, filename);
+
+                    const file = new File([blob], filename, { type: blob.type });
+                    const dataTransfer = new DataTransfer();
+                    dataTransfer.items.add(file);
+
+                    console.log(`[DEBUG] Mostaql Notifier: Resetting fileInput value...`);
+                    fileInput.value = '';
+
+                    console.log(`[DEBUG] Mostaql Notifier: Created File and DataTransfer object with unique name.`);
+                    fileInput.files = dataTransfer.files;
+
+                    console.log(`[DEBUG] Mostaql Notifier: Dispatching 'change' event to fileInput...`);
+                    const changeEvent = new Event('change', { bubbles: true });
+                    fileInput.dispatchEvent(changeEvent);
+
+                    imagePasted = true;
+                    console.log(`[DEBUG] Mostaql Notifier: Auto-upload triggered successfully!`);
+                }
+            }
+
+            if (imagePasted) {
+                console.log(`[DEBUG] Mostaql Notifier: Preventing default paste action.`);
+                event.preventDefault();
+            } else {
+                console.log(`[DEBUG] Mostaql Notifier: No image item was pasted, letting default paste event run.`);
+            }
+        });
+        console.log('[DEBUG] Mostaql Notifier: Main world clipboard paste hook installed successfully');
+    }
+
+    // Set up a MutationObserver to watch for dynamic DOM shifts or chat switches
+    const observer = new MutationObserver(() => {
+        initMainWorldClipboard();
+    });
+
+    observer.observe(document.documentElement, {
+        childList: true,
+        subtree: true
+    });
+
+    // Also run immediately
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initMainWorldClipboard);
+    } else {
+        initMainWorldClipboard();
+    }
+})();

--- a/content/clipboard.js
+++ b/content/clipboard.js
@@ -1,0 +1,27 @@
+// ==========================================
+// content/clipboard.js — Injects main-world paste hook script tag
+// ==========================================
+
+function injectClipboardPaste() {
+    const chatInput = document.querySelector('.editor__input');
+    const fileInput = document.querySelector('.chat-form__multimedia input[type="file"]');
+
+    if (!chatInput || !fileInput) return;
+
+    // Check if already injected
+    if (chatInput.dataset.clipboardPasteHooked === 'true') return;
+    chatInput.dataset.clipboardPasteHooked = 'true';
+
+    console.log('[DEBUG] Mostaql Notifier: Injecting clipboard script tag from web_accessible_resources');
+
+    // Create a script tag pointing to the web-accessible resource
+    const script = document.createElement('script');
+    script.src = chrome.runtime.getURL('content/clipboard-main.js');
+    
+    // Inject and immediately remove once loaded to keep DOM clean
+    script.onload = function() {
+        script.remove();
+    };
+
+    (document.head || document.documentElement).appendChild(script);
+}

--- a/content/init.js
+++ b/content/init.js
@@ -15,8 +15,9 @@ function runInjectors() {
         checkForAutofill();
     }
 
-    if (page === 'message') {
+    if (page === 'message' || page === 'messages') {
         injectMessageExporter();
+        injectClipboardPaste();
     }
 
     if (page === 'home') {

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
         "content/export.js",
         "content/home.js",
         "content/profile.js",
+        "content/clipboard.js",
         "content/init.js"
       ],
       "css": [
@@ -61,5 +62,15 @@
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "content/clipboard-main.js"
+      ],
+      "matches": [
+        "https://mostaql.com/*"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Description
This PR adds support for programmatically pasting images (`Ctrl + V`) directly into the Mostaql chat input field, triggering an automatic file attachment and upload sequence without manual plus-button interactions.

## Key Changes
- **Isolated & Main World Dynamic Injection**: Solved Chrome Extension isolated-world and dynamic SPA route boundaries by dynamically injecting the native hook as a web-accessible script tag (`content/clipboard-main.js`) directly in the page's MAIN execution world.
- **CSP Compliance**: Resolved inline-script blocking by configuring the main-world hook script inside `web_accessible_resources` (safely loaded from the extension's whitelisted origin).
- **Multi-Paste Support**: Added random timestamped filename generations (`pasted_image_[timestamp]_[rand].png`) to force host state engines to recognize consecutive pastes as brand-new selections.
- **State Mismatch Prevention**: Programmatically cleared native file input values (`fileInput.value = ''`) prior to each payload assignment, allowing unlimited attachment/deletion/re-pasting loops.
- **Lifecycle Integration**: Wired `injectClipboardPaste()` directly into the extension's existing observer cycle (`init.js`) to support dynamic chat updates and thread-switches.

## Verification
- Verified successive image pastes attach and queue up successfully in chat rooms.
- Verified delete/remove event recovery loops.
- Verified logs and CSP-compliance natively in dev consoles on `/message/` routes.


https://github.com/user-attachments/assets/2e3a4ee5-37eb-4e38-9c65-f36982a5dcc4


